### PR TITLE
Fix favicon loading bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>gamelab</title>
-  <link rel="icon" type="image/png" href="./assets/favicon/loading.gif">
+  <link rel="icon" type="image/png" href="./assets/favicon/yellow.png">
   <link rel="stylesheet" href="./styles/editor.css"></link>
   <link rel="stylesheet" href="./styles/cursors.css"></link>
   <!-- <link rel="stylesheet" href="./styles/tooltip.css"></link> -->

--- a/init.js
+++ b/init.js
@@ -144,6 +144,7 @@ function setGameIframe() {
 }
 
 export async function init(state) {
+  dispatch("FAVICON", 'loading.gif');
   initVert();
 
   state.runStatus = "loading";


### PR DESCRIPTION
This fixes an issue where indexers and scrapers would grab the loading.gif as the site's favicon