### PR TITLE
Add checkerboard pattern to transparent color option

### DIFF
--- a/checkerboard.svg
+++ b/checkerboard.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M0 0H4V4H0V0ZM4 4H8V8H4V4Z" fill="black" fill-opacity="0.45"/>
-</svg>

--- a/checkerboard.svg
+++ b/checkerboard.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M0 0H4V4H0V0ZM4 4H8V8H4V4Z" fill="black" fill-opacity="0.45"/>
+</svg>

--- a/pixel-editor/pixel-editor.js
+++ b/pixel-editor/pixel-editor.js
@@ -239,6 +239,10 @@ export function createPixelEditor(target) {
           @click=${() => { state.color = color[1]; r(); }}>
         </div>
       `
+
+    return html`
+      <div class="colors">${state.palette.map(drawColor)}</div>
+    `
     }
   };
 

--- a/pixel-editor/pixel-editor.js
+++ b/pixel-editor/pixel-editor.js
@@ -226,16 +226,20 @@ export function createPixelEditor(target) {
   `;
 
   const drawColorsButtons = (state) => {
-    const drawColor = (color) => html`
-      <div 
-        class=${RGBA_to_hex(state.color) === RGBA_to_hex(color[1]) ? "active" : ""}
-        style=${`background-color: ${RGBA_to_hex(color[1])}`}
-        @click=${() => { state.color = color[1]; r(); }}>
-      </div>
-    `
-    return html`
-      <div class="colors">${state.palette.map(drawColor)}</div>
-    `
+    const drawColor = (color) => {
+      const isTransparent = color[1][3] === 0;
+      
+      let style = `background-color: ${RGBA_to_hex(color[1])};`;
+      isTransparent ? style += ` background-image: url("/checkerboard.svg")` : ``
+
+      return html`
+        <div 
+          class=${RGBA_to_hex(state.color) === RGBA_to_hex(color[1]) ? "active" : ""}
+          style=${style}
+          @click=${() => { state.color = color[1]; r(); }}>
+        </div>
+      `
+    }
   };
 
   const r = () => {

--- a/pixel-editor/pixel-editor.js
+++ b/pixel-editor/pixel-editor.js
@@ -239,11 +239,11 @@ export function createPixelEditor(target) {
           @click=${() => { state.color = color[1]; r(); }}>
         </div>
       `
+    }
 
     return html`
       <div class="colors">${state.palette.map(drawColor)}</div>
     `
-    }
   };
 
   const r = () => {

--- a/pixel-editor/pixel-editor.js
+++ b/pixel-editor/pixel-editor.js
@@ -230,7 +230,7 @@ export function createPixelEditor(target) {
       const isTransparent = color[1][3] === 0;
       
       let style = `background-color: ${RGBA_to_hex(color[1])};`;
-      isTransparent ? style += ` background-image: url("/checkerboard.svg")` : ``
+      isTransparent ? style += ` background-image: url("data:image/svg+xml,%0A%3Csvg width='23' height='23' viewBox='0 0 8 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='8' height='8' fill='white'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M0 0H4V4H0V0ZM4 4H8V8H4V4Z' fill='%23DCEFFC'/%3E%3C/svg%3E%0A");` : ``
 
       return html`
         <div 


### PR DESCRIPTION
Tiny change that adds a checkerboard SVG to the "transparent" color option in the pixel editor (so it's more clear what that button does).