### PR TITLE
CVE-2022-2596 Fixed [node-fetch Inefficient Regular Expression Complexity]

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -511,9 +511,9 @@ node-domexception@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@^3.2.9:
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.9.tgz#3f6070bf854de20f21b9fe8479f823462e615d7d"
+node-fetch@^3.2.10:
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.10.tgz#3f6070bf854de20f21b9fe8479f823462e615d7d"
   integrity sha512-/2lI+DBecVvVm9tDhjziTVjo2wmTsSxSk58saUYP0P/fRJ3xxtfMDY24+CKTkfm0Dlhyn3CSXNL0SoRiCZ8Rzg==
   dependencies:
     data-uri-to-buffer "^4.0.0"


### PR DESCRIPTION
Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) in the ``isOriginPotentiallyTrustworthy()`` function in ``referrer.js``, when processing a URL string with alternating letters and periods, such as ``'http://' + 'a.a.'.repeat(i) + 'a'.``