### PR TITLE
Remove empty tags from metadata.json

### DIFF
--- a/games/metadata.json
+++ b/games/metadata.json
@@ -242,13 +242,13 @@
     "title": "confusing_conditions",
     "author": "Sooraj",
     "img": "",
-    "tags": [""]
+    "tags": []
   },
   {
     "filename": "Virtual_Machine",
     "title": "Virtual_Machine",
     "author": "N_Rizwan",
     "img": "",
-    "tags": [""]
+    "tags": []
   }
 ]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/51027259/189242784-a2b3f65a-6f66-4a41-920c-29b40c18634d.png)
Empty string tags caused a weird visual glitch, removed those tags