### PR TITLE
Fix metadata.json for reactor.js

### DIFF
--- a/games/metadata.json
+++ b/games/metadata.json
@@ -140,7 +140,7 @@
     "tags": ["hackable"]
   },   
   {
-    "filename": "reaction_timer",
+    "filename": "reactor",
     "title": "reaction_timer",
     "author": "sampoder",
     "img": "",

--- a/games/metadata.json
+++ b/games/metadata.json
@@ -329,13 +329,6 @@
     "tags": []
   },
   {
-    "filename": "reaction_timer",
-    "title": "reaction_timer",
-    "author": "sampoder",
-    "img": "",
-    "tags": ["multiplayer"]
-  },
-  {
     "filename": "tetris",
     "title": "tetris",
     "author": "neesh",


### PR DESCRIPTION
Fixes duplicate entry for [`reactor.js`](https://github.com/hackclub/sprig/blob/main/games/reactor.js) by @sampoder.
Changes filename to `reactor` so it does not 404.