### PR TITLE
Fixed: Repeatedly pressing shoot key after dying throws error

### DIFF
--- a/games/shoot_green_blobs.js
+++ b/games/shoot_green_blobs.js
@@ -436,6 +436,7 @@ onInput("d", () => {
 
 onInput("j", () => {
   const p = gameState.player
+  if(!p) return
   if (p.playback && p.playback.end) p.playback.end() // no optional chaining? :(
   if (getAll(bullet).length) {
     p.playback = playTune(sounds.cannotFire)


### PR DESCRIPTION
This fix is for the game: `Shoot green blobs`

On repeatedly pressing "J" key for shooting even after dying throws the following error:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'playback') on line 439 in column 9. 
Open the browser console for more information.
```

Fixed it in the commit below 👍 