### PR TITLE
Add error about Web Serial API

### DIFF
--- a/upload.js
+++ b/upload.js
@@ -12,7 +12,7 @@ function delay(ms) {
 
 async function getPort() {
   if (navigator.serial === undefined)
-    throw "error: your browser does not support the Web Serial API. please try again in a recent version of Chrome.";
+    throw "your browser does not support the Web Serial API. please try again in a recent version of Chrome.";
   const ports = await navigator.serial.getPorts();
   if (ports.length !== 1) {
     dispatch("UPLOAD_LOG", "please pick a device.");

--- a/upload.js
+++ b/upload.js
@@ -11,6 +11,8 @@ function delay(ms) {
 }
 
 async function getPort() {
+  if (navigator.serial === undefined)
+    throw "error: your browser does not support the Web Serial API. please try again in a recent version of Chrome.";
   const ports = await navigator.serial.getPorts();
   if (ports.length !== 1) {
     dispatch("UPLOAD_LOG", "please pick a device.");


### PR DESCRIPTION
Add an explicit error on pushing to a device if the browser does not support the Web Serial API