### PR TITLE
Remove getState from games

### DIFF
--- a/games/Breakout.js
+++ b/games/Breakout.js
@@ -9,8 +9,6 @@ const ball = "o";
 const background = "s";
 let Score = 0;
 let playerSpeed = 6;
-const mapHeight = getState().dimensions.height;
-const mapWidth = getState().dimensions.width;
 
 setLegend(
   [ playerL, bitmap`
@@ -159,8 +157,6 @@ function makeSound() {
 }
 
 let gameInterval = setInterval(() => {
-  const mapHeight = getState().dimensions.height;
-  const mapWidth = getState().dimensions.width;
   let ballOne = getFirst(ball)
   let positionBeforeX = ballOne.x;
   ballOne.x += headingX;
@@ -193,7 +189,7 @@ let gameInterval = setInterval(() => {
   }
 
   //you lose!  
-  if (ballOne.y >= mapHeight -1) {
+  if (ballOne.y >= height() -1) {
     playTune(loseSound);
     ballOne.remove();
     clearText()

--- a/games/desi-pong.js
+++ b/games/desi-pong.js
@@ -234,13 +234,11 @@ function writeScore() {
 }
 
 function restart(sprite) {
-  const mapHeight = getState().dimensions.height;
-  const mapWidth = getState().dimensions.width;
   writeScore()
   ballDx = 0;
   ballDy = 0;
-  sprite.x = Math.round(mapWidth / 2);
-  sprite.y = Math.round(mapHeight / 2);
+  sprite.x = Math.round(width() / 2);
+  sprite.y = Math.round(height() / 2);
   setTimeout(() => {
     ballDx = Math.random() < 0.5 ? -1 : 1;
     ballDy = Math.random() < 0.5 ? -2 : 2;
@@ -263,10 +261,8 @@ function control(){
   const sprite = getFirst(ball);
   sprite.x += ballDx;
   sprite.y += ballDy;
-  const mapHeight = getState().dimensions.height;
-  const mapWidth = getState().dimensions.width;
   
-  if (sprite.y >= mapHeight - 2) {
+  if (sprite.y >= height() - 2) {
     ballDy = Math.abs(ballDy) * -1;
     makeSound()
   }
@@ -282,7 +278,7 @@ function control(){
     ballDx = ballDx * -1;
     makeSound()
   }
-  else if (sprite.x >= mapWidth - 1) {
+  else if (sprite.x >= width() - 1) {
     player1Score += 1;
     playTune(pointSound);
     restart(sprite)

--- a/games/pong.js
+++ b/games/pong.js
@@ -216,13 +216,11 @@ function writeScore() {
 }
 
 function restart(sprite) {
-  const mapHeight = getState().dimensions.height;
-  const mapWidth = getState().dimensions.width;
   writeScore()
   ballDx = 0;
   ballDy = 0;
-  sprite.x = Math.round(mapWidth / 2);
-  sprite.y = Math.round(mapHeight / 2);
+  sprite.x = Math.round(width() / 2);
+  sprite.y = Math.round(height() / 2);
   setTimeout(() => {
     ballDx = Math.random() < 0.5 ? -1 : 1;
     ballDy = Math.random() < 0.5 ? -2 : 2;
@@ -243,10 +241,8 @@ setInterval(() => {
   const sprite = getFirst(ball);
   sprite.x += ballDx;
   sprite.y += ballDy;
-  const mapHeight = getState().dimensions.height;
-  const mapWidth = getState().dimensions.width;
   
-  if (sprite.y >= mapHeight - 2) {
+  if (sprite.y >= height() - 2) {
     ballDy = Math.abs(ballDy) * -1;
     makeSound()
   }
@@ -262,7 +258,7 @@ setInterval(() => {
     ballDx = ballDx * -1;
     makeSound()
   }
-  else if (sprite.x >= mapWidth - 1) {
+  else if (sprite.x >= width() - 1) {
     player1Score += 1;
     playTune(pointSound);
     restart(sprite)
@@ -280,8 +276,6 @@ setInterval(() => {
 let aiYValues;
 setInterval(() => {
   const sprite = getFirst(ball);
-  const mapHeight = getState().dimensions.height;
-  const mapWidth = getState().dimensions.width;
 
   if (ballDx < 0) {
     aiSpeed = 1;


### PR DESCRIPTION
Pong, Breakout, and Desi-Pong all used `getState` to get the map dimensions. This is a browser implementation detail and doesn't exist on the Sprig, causing these games to break.

I updated the games to use the `width` and `height` functions instead. I'll be adding these to the docs as well as a note to avoid `getState`.
