### PR TITLE
Add support for non-QWERTY keyboard layouts

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -125,7 +125,7 @@ Sprig has eight inputs  `w`, `a`, `s`, `d`, `i`, `j`, `k`, `l`.
 
 Typically `w`, `a`, `s`, `d` are used as directional controls.
 
-In case you're using a different keyboard layout, arrow keys are mapped to WASD and `1`, `2`, `3`, and `4` map to `i`, `j`, `k`, and `l` respectively (although you still need to refer to the inputs by the non-mapped names in your code).
+In case you're using a different keyboard layout, arrow keys are mapped to WASD and `1`, `2`, `3`, and `4` map to `j`, `k`, `i`, and `l` respectively (although you still need to refer to the inputs by the non-mapped names in your code).
 
 ### onInput(type, callback)
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -125,6 +125,8 @@ Sprig has eight inputs  `w`, `a`, `s`, `d`, `i`, `j`, `k`, `l`.
 
 Typically `w`, `a`, `s`, `d` are used as directional controls.
 
+In case you're using a different keyboard layout, arrow keys are mapped to WASD and `1`, `2`, `3`, and `4` map to `i`, `j`, `k`, and `l` respectively (although you still need to refer to the inputs by the non-mapped names in your code).
+
 ### onInput(type, callback)
 
 Do something when the player presses a control:

--- a/docs/es-docs.md
+++ b/docs/es-docs.md
@@ -120,7 +120,7 @@ Gamelab tiene ocho entradas  `w`, `a`, `s`, `d`, `i`, `j`, `k`, `l`.
 
 Típicamente `w`, `a`, `s`, `d` se utilizan como controles direccionales.
 
-En caso de que esté utilizando un diseño de teclado diferente, las teclas de flecha se asignan a WASD y `1`, `2`, `3` y `4` se asignan a `i`, `j`, `k` y ` l` respectivamente (aunque todavía necesita referirse a las entradas por los nombres no asignados en su código). <!-- TODO: this is translated via Google Translate, verify the translation is correct -->
+En caso de que esté utilizando un diseño de teclado diferente, las teclas de flecha se asignan a WASD y `1`, `2`, `3` y `4` se asignan a `j`, `k`, `i`, and `l` respectivamente (aunque todavía necesita referirse a las entradas por los nombres no asignados en su código). <!-- TODO: this is translated via Google Translate, verify the translation is correct -->
 
 ### onInput(type, callback)
 

--- a/docs/es-docs.md
+++ b/docs/es-docs.md
@@ -120,7 +120,7 @@ Gamelab tiene ocho entradas  `w`, `a`, `s`, `d`, `i`, `j`, `k`, `l`.
 
 Típicamente `w`, `a`, `s`, `d` se utilizan como controles direccionales.
 
-En caso de que esté utilizando un diseño de teclado diferente, las teclas de flecha se asignan a WASD y `1`, `2`, `3` y `4` se asignan a `j`, `k`, `i`, and `l` respectivamente (aunque todavía necesita referirse a las entradas por los nombres no asignados en su código). <!-- TODO: this is translated via Google Translate, verify the translation is correct -->
+En caso de que esté utilizando un diseño de teclado diferente, las teclas de flecha se asignan a WASD y `1`, `2`, `3` y `4` se asignan a `j`, `k`, `i`, and `l` respectivamente (aunque todavía necesitan referirse a las entradas por los nombres no asignados en su código).
 
 ### onInput(type, callback)
 

--- a/docs/es-docs.md
+++ b/docs/es-docs.md
@@ -120,6 +120,8 @@ Gamelab tiene ocho entradas  `w`, `a`, `s`, `d`, `i`, `j`, `k`, `l`.
 
 Típicamente `w`, `a`, `s`, `d` se utilizan como controles direccionales.
 
+En caso de que esté utilizando un diseño de teclado diferente, las teclas de flecha se asignan a WASD y `1`, `2`, `3` y `4` se asignan a `i`, `j`, `k` y ` l` respectivamente (aunque todavía necesita referirse a las entradas por los nombres no asignados en su código). <!-- TODO: this is translated via Google Translate, verify the translation is correct -->
+
 ### onInput(type, callback)
 
 Hacer algo cuando el jugador presiona un control:

--- a/engine/webEngine.js
+++ b/engine/webEngine.js
@@ -125,15 +125,30 @@ export function init(canvas, headless = false, runDispatch = true) {
   };
   let afterInputs = [];
 
-  const VALID_INPUTS = ["w", "a", "s", "d", "i", "j", "k", "l"];
+  const KEY_MAPPINGS = {
+    "w": "w",
+    "a": "a",
+    "s": "s",
+    "d": "d",
+    "i": "i",
+    "j": "j",
+    "k": "k",
+    "l": "l",
+    "ArrowUp": "w",
+    "ArrowDown": "s",
+    "ArrowLeft": "a",
+    "ArrowRight": "d",
+    "1": "j",
+    "2": "k",
+    "3": "i",
+    "4": "l",
+  };
   canvas.addEventListener("keydown", (e) => {
     const key = e.key;
 
-    if (!VALID_INPUTS.includes(key)) return;
+    if (!(key in KEY_MAPPINGS)) return;
 
-    for (const valid_key of VALID_INPUTS)
-      if (key == valid_key)
-        tileInputs[key].forEach(fn => fn());
+    tileInputs[KEY_MAPPINGS[key]].forEach(fn => fn());
 
     afterInputs.forEach(f => f());
 
@@ -147,7 +162,7 @@ export function init(canvas, headless = false, runDispatch = true) {
 
   function onInput(type, fn) {
     if (!(type in tileInputs)) throw new Error(
-      `Unknown input key, "${type}": expected one of ${VALID_INPUTS.join(', ')}`
+      `Unknown input key, "${type}": expected one of ${[...new Set(Object.values(KEY_MAPPINGS))].join(', ')}`
     )
     tileInputs[type].push(fn);
   }


### PR DESCRIPTION
This adds support for an alternate keybinding for the web editor, namely up/left/down/right/3/1/2/4 instead of w/a/s/d/i/j/k/l. This allows users who do not use the QWERTY keyboard layout to play Sprig games. For example, I use Colemak, so without this change I have to stretch my hand across the `w`, `a`, `d`, and `g` keys (and `l`, `y`, `n`, `u` for ijkl!).

This partially resolves #499; being able to configure the keys from the web interface would be better (especially considering the new mapping is suboptimal since it had to work for all layouts), but it didn't seem like development on that front was going to happen so I thought I'd make this quick/simple patch.

# Your checklist for this pull request

yeah sure why not fill this out?

## About your game

What is your game about?
> Example: Pushing boxes to the goal. (from [Sokoban Plus](https://editor.sprig.hackclub.com/?file=https://raw.githubusercontent.com/hackclub/sprig/main/games/sokoban_plus.js))

This is in fact a removal of a game - the game of Twister which non-QWERTY users had to play with their hands and keyboard to use Sprig.

How to play your game?
> Example  : Press WASD to move, J to restart and K to toggle trails, Get A boxes (cyan) to A goals (green), Get B boxes (magenta) to B goals (red), Get normal boxes (gray) to either goal. (from [Sokoban plus](https://editor.sprig.hackclub.com/?file=https://raw.githubusercontent.com/hackclub/sprig/main/games/sokoban_plus.js))

See above for key mappings!

## Code
Check off the items that are true.
- [ ] The game was made using the [Sprig editor](https://editor.sprig.hackclub.com/). _nope, I used VS Code for my changes_
- [x] The game is placed in the in the [`/games` directory](https://github.com/hackclub/sprig/tree/main/games). _I think moving the engine to the games directory would break things significantly, happy to do that if you want_
- [x] The code is significantly different from all other games in the [Sprig gallery](https://sprig.hackclub.com/gallery) (except for games labeled "demo"). _yep I think so_
- [x] The game runs without errors. _it does_
- [x] The name of the file/game contains only alphanumeric characters, `-`s, or `_`s. _yep_
- [x] The game name is not the same as the others from [gallery](https://sprig.hackclub.com/gallery) _I'd be very surprised if someone made a game called `webengine.js`_

## Image (If an image is used)

- [ ] The image is in the [`/games/img` directory](https://github.com/hackclub/sprig/tree/main/games/img).
- [ ] The name of the image matches the name of your file. Example: `sokoban_plus.js` -> `sokoban_plus.png`.

> Thanks for PR!
