### PR TITLE
Add Support for Firefox 91

### DIFF
--- a/index.css
+++ b/index.css
@@ -288,6 +288,16 @@ body {
   outline: none;
 }
 
+@-moz-document url-prefix() {
+  /* Hack to support Firefox 91 (ESR in use on debian) */
+  .game-text {
+    image-rendering: crisp-edges;
+  }
+  .game-canvas {
+    image-rendering: crisp-edges;
+  }
+}
+
 .docs {
   background: var(--bg-surface);
   height: 0;


### PR DESCRIPTION
Firefox 91 is the current ESR on debian 11
It is also the last (recentish) version of a browser to not support image-rendering: pixelated;
So for now, it is changed to image-rendering: crisp-edges; on firefox browsers

## About your game

What is your game about? 
> Example: Pushing boxes to the goal. (from [Sokoban Plus](https://editor.sprig.hackclub.com/?file=https://raw.githubusercontent.com/hackclub/sprig/main/games/sokoban_plus.js))

making existing games work on Firefox 91 (The ESR on debian 11)

How to play your game?
> Example  : Press WASD to move, J to restart and K to toggle trails, Get A boxes (cyan) to A goals (green), Get B boxes (magenta) to B goals (red), Get normal boxes (gray) to either goal. (from [Sokoban plus](https://editor.sprig.hackclub.com/?file=https://raw.githubusercontent.com/hackclub/sprig/main/games/sokoban_plus.js))

Load in firefox ESR on debian, or otherwise in firefox 91
Observe that firefox's sprites are no longer blurry
NOTE: this also affects sprig-gallery (the homepage, specifically).

## Code
Check off the items that are true.
- [ ] The game was made using the [Sprig editor](https://editor.sprig.hackclub.com/).
- [ ] The game is placed in the in the [`/games` directory](https://github.com/hackclub/sprig/tree/main/games).
- [x] The code is significantly different from all other games in the [Sprig gallery](https://sprig.hackclub.com/gallery) (except for games labeled "demo").
- [x] The game runs without errors. 
- [x] The name of the file/game contains only alphanumeric characters, `-`s, or `_`s.
- [x] The game name is not the same as the others from [gallery](https://sprig.hackclub.com/gallery)

## Image (If an image is used)

- [ ] The image is in the [`/games/img` directory](https://github.com/hackclub/sprig/tree/main/games/img).
- [ ] The name of the image matches the name of your file. Example: `sokoban_plus.js` -> `sokoban_plus.png`.

> Thanks for PR!
