### PR TITLE
Add strong typings

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -8,11 +8,10 @@ declare global {
 	type Tune = string & { __brand: "tune" }
 
 	type Sprite = {
-		_type: string
-		_x: number
-		_y: number
-		dx: number
-		dy: number
+		type: string
+		x: number
+		y: number
+		remove: () => Sprite
 	}
 
 	type InputKey = "w" | "a" | "s" | "d" | "i" | "j" | "k" | "l"
@@ -40,10 +39,7 @@ declare global {
 	function getFirst(type: Key): Sprite
 
 	/* Text */
-	function addText(
-		text: string,
-		options?: { x?: number; y?: number; color?: Color }
-	): void
+	function addText(text: string, options?: { x?: number; y?: number; color?: Color }): void
 	function clearText(): void
 
 	/* Music */

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,76 @@
+export {}
+
+declare global {
+	type Key = string & {}
+	type Bitmap = string & { __brand: "bitmap" }
+	type SprigMap = string & { __brand: "sprigmap" }
+	type Color = string & { __brand: "color" }
+	type Tune = string & { __brand: "tune" }
+
+	type Sprite = {
+		_type: string
+		_x: number
+		_y: number
+		dx: number
+		dy: number
+	}
+
+	type InputKey = "w" | "a" | "s" | "d" | "i" | "j" | "k" | "l"
+	type Playback = { end: () => void }
+
+	/* Level Design */
+	function setLegend(...bitmaps: [Key, Bitmap][]): void
+	function setBackground(bitmapKey: Key): void
+	function setMap(level: SprigMap): void
+	function setSolids(bitmapKeys: Key[]): void
+	function setPushables(pushMap: Record<Key, Key[]>): void
+	function width(): number
+	function height(): number
+
+	/* User Input */
+	function onInput(key: InputKey, cb: () => void): void
+	function afterInput(cb: () => void): void
+
+	/* Sprites and Tiles */
+	function getTile(x: number, y: number): Sprite[]
+	function tilesWith(...type: Key[]): Sprite[][]
+	function addSprite(x: number, y: number, spriteType: Key): void
+	function clearTile(x: number, y: number): void
+	function getAll(type: Key): Sprite[]
+	function getFirst(type: Key): Sprite
+
+	/* Text */
+	function addText(
+		text: string,
+		options?: { x?: number; y?: number; color?: Color }
+	): void
+	function clearText(): void
+
+	/* Music */
+	function playTune(tune: Tune, repeat?: number): Playback
+
+	/* Debugging */
+	function getState(): {
+		background: Key
+		dimensions: {
+			width: number
+			height: number
+		}
+		legend: [Key, Bitmap][]
+		pushable: Record<Key, Key[]>
+		solids: Key[]
+		sprites: Sprite[]
+		texts: {
+			color: [number, number, number, number]
+			content: string
+			x: number
+			y: number
+		}[]
+	}
+
+	/* Tagged template literals */
+	function bitmap(template: TemplateStringsArray, ...params: string[]): Bitmap
+	function map(template: TemplateStringsArray, ...params: string[]): SprigMap
+	function color(template: TemplateStringsArray, ...params: string[]): Color
+	function tune(template: TemplateStringsArray, ...params: string[]): Tune
+}


### PR DESCRIPTION
This PR adds a `global.d.ts` file that can be used when developing a Sprig game using TypeScript.
I've covered all of the methods available in the documentation, but perhaps there are some I'm not aware of.
Even though keys, bitmaps, maps, colors and tunes are still strings, I'm using branded types to differenciate them


- [x] Level Design
    - [x] `setLegend`
    - [x] `setBackground `
    - [x] `setMap`
    - [x] `setSolids`
    - [x] `setPushables`
    - [x] `width`
    - [x] `height`
- [x] User Input
    - [x] `onInput`
    - [x] `afterInput`
- [x] Sprites and Tiles
    - [x] `getTile`
    - [x] `tilesWith`
    - [x] `addSprite`
    - [x] `getAll`
    - [x] `getFirst`
    - [x] `Sprite.remove` 
- [x] Text
    - [x] `addText`
    - [x] `clearText` 
- [x] Music
    - [x] `playTune`
    - [x] `Playback.end` 
- [x] Debugging 
    - [x] `getState`  
- [x] Tagged Template Literals
    - [x] `bitmap`
    - [x] `map`
    - [x] `color`
    - [x] `tune` 