### PR TITLE
feature: Return sprite in web engine's addSprite()

### DIFF
--- a/engine/baseEngine.js
+++ b/engine/baseEngine.js
@@ -153,6 +153,7 @@ export function baseEngine() {
 
     const s = new Sprite(type, x, y);
     state.sprites.push(s);
+    return s;
   }
   
   const _allEqual = arr => arr.every(val => val === arr[0]);


### PR DESCRIPTION
The spade implementation of  `addSprite()` returns a sprite.

```
JERRYXX_FUN(addSprite) {

  dbg("module_native::addSprite");
  JERRYXX_CHECK_ARG_NUMBER(0, "x");
  JERRYXX_CHECK_ARG_NUMBER(1, "y");
  JERRYXX_CHECK_ARG(2, "type");
  Sprite *s = map_add(
    JERRYXX_GET_ARG_NUMBER(0),
    JERRYXX_GET_ARG_NUMBER(1),
    jerry_value_to_char(JERRYXX_GET_ARG(2))
  );

  if (s == 0)
    return jerry_create_error(
      JERRY_ERROR_COMMON,
      (jerry_char_t *)"addSprite failed: sprite out of bounds, or too many sprites"
    );
  else
    return sprite_to_jerry_object(s);
}
```

The web engine code doesn't return a sprite.

```
  const addSprite = (x, y, type) => {
    if (type === ".") return;

    _checkBounds(x, y);
    _checkLegend(type);

    const s = new Sprite(type, x, y);
    state.sprites.push(s);
  }
```

I'd suggest normalizing the behavior of the APIs, and I'd suggest choosing spade's convention for the following reasons:

1. It's a non-breaking change to start returning objects.

2. And it's a little unergonomic to get your sprite without it.

```
addSprite(x, y, player);
let tiles = getTile(x,y);
let sprite = tiles[tiles.length - 1];
```

vs

```
let sprite = addSprite(x, y, player);
```
