### PR TITLE
Constrain BPM input in the Sequencer.

### DIFF
--- a/sequencer/sequencer.js
+++ b/sequencer/sequencer.js
@@ -308,7 +308,7 @@ export function createSequencer(target) {
 
   const handleBpmInput = (e) => {
     if (e.target.value.length > 4) return r();
-    if (e.target.value < 1) state.bpm = Number(1) * 2;
+    if (e.target.value < 1) state.bpm = 2; // 1 * 2
     else state.bpm = Number(e.target.value) * 2;
     state.data.bpm = state.bpm;
     if (state.interval) {

--- a/sequencer/sequencer.js
+++ b/sequencer/sequencer.js
@@ -308,7 +308,8 @@ export function createSequencer(target) {
 
   const handleBpmInput = (e) => {
     if (e.target.value.length > 4) return r();
-    state.bpm = Number(e.target.value) * 2;
+    if (e.target.value < 1) state.bpm = Number(1) * 2;
+    else state.bpm = Number(e.target.value) * 2;
     state.data.bpm = state.bpm;
     if (state.interval) {
       clearInterval(state.interval);


### PR DESCRIPTION
Fixing [this issue](https://github.com/hackclub/sprig/issues/617) by not letting the user input 0 (or lower), and the minimum BPM you can go is 1 (even though that is quite slow, that is the lowest you can go by setting the BPM through the slider).
<br><br>
Since there is a bug about the Map, Sprite and Tune editors not showing up, deleting the top comment about being an author brought them back, for some reason.