### PR TITLE
Sequencer now plays selected note

### DIFF
--- a/sequencer/sequencer.js
+++ b/sequencer/sequencer.js
@@ -394,10 +394,12 @@ export function createSequencer(target) {
   };
 
   const play = () => setInterval(() => {
-    state.beat = (state.beat+1) % (state.numberX);
     // play song
     playCellsOnBeat(state.cells, state.bpm, state.beat);
     r();
+
+    // update beat
+    state.beat = (state.beat+1) % (state.numberX);
   }, (1000*60)/state.bpm)
 
   const init = (state) => {


### PR DESCRIPTION
Fixed [this issue](https://github.com/hackclub/sprig/issues/711) by updating the next note *after* playing the selected one, instead of it being the other way around.