### PR TITLE
Capitalise "Games" / "Game"

### DIFF
--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -141,12 +141,12 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 			<ul>
 				{props.persistenceState.value.session?.session.full
 					? (<>
-						<li><a href='/~'>Your games</a></li>
-						<li><a href='/~/new'>New game</a></li>
+						<li><a href='/~'>Your Games</a></li>
+						<li><a href='/~/new'>New Game</a></li>
 					</>)
 					: (<>
 						<li><a href='/'>Home</a></li>
-						<li><a href='/~'>Your games (log in)</a></li>
+						<li><a href='/~'>Your Games (log in)</a></li>
 					</>)}
 				<li><a href='/gallery'>Gallery</a></li>
 				<li><a href='/get'>Get a Sprig</a></li>


### PR DESCRIPTION
Feels right because "Get a Sprig" is capitalised... though Sprig is a brand name