### PR TITLE
bug: Add the_hungry_mouse to the metadata.

### DIFF
--- a/games/metadata.json
+++ b/games/metadata.json
@@ -2224,6 +2224,14 @@
     "addedOn": "2023-02-26"
   },
   {
+    "filename": "the_hungry_mouse",
+    "title": "The Hungry Mouse",
+    "author": "Kai Etkin",
+    "img": "the_hungry_mouse",
+    "tags": ["puzzle", "maze"],
+    "addedOn": "2023-03-01"
+  },
+  {
     "filename": "the_dining_room_in_the_sky",
     "title": "the_dining_room_in_the_sky",
     "author": "Dylan Tran",


### PR DESCRIPTION
It should show up in the gallery now.