### PR TITLE
Fix migration in Firefox and Safari

### DIFF
--- a/src/components/big-interactive-pages/migrate.tsx
+++ b/src/components/big-interactive-pages/migrate.tsx
@@ -32,7 +32,7 @@ export default function Migrate({ session, intitialEmail }: MigrateProps) {
 	useEffect(() => {
 		let cancel = false
 
-		getPuzzleLabFromLocalStorage().then(data => {
+		getPuzzleLabFromLocalStorage(true).then(data => {
 			if (cancel) return
 
 			let json: [string, string][]

--- a/src/components/popups-etc/draft-warning.module.css
+++ b/src/components/popups-etc/draft-warning.module.css
@@ -70,3 +70,16 @@ p.muted {
 .error {
 	color: var(--error);
 }
+
+.warning {
+	background: #fff9db;
+	color: #9f6220;
+	padding: 10px;
+	line-height: var(--line-height-copy);
+	font-size: 0.9rem;
+}
+
+.warning a {
+	color: #000000;
+	text-decoration: underline;
+}

--- a/src/components/popups-etc/draft-warning.tsx
+++ b/src/components/popups-etc/draft-warning.tsx
@@ -1,5 +1,6 @@
 import type { Signal } from '@preact/signals'
 import { persist, useAuthHelper } from '../../lib/game-saving/auth-helper'
+import { useNeedsManualMigration } from '../../lib/game-saving/legacy-migration'
 import type { PersistenceState } from '../../lib/state'
 import Button from '../design-system/button'
 import Input from '../design-system/input'
@@ -12,11 +13,18 @@ export interface DraftWarningModalProps {
 
 export default function DraftWarningModal(props: DraftWarningModalProps) {
 	const auth = useAuthHelper('EMAIL_ENTRY')
+	const needsManualMigration = useNeedsManualMigration()
 
 	return (
 		<div class={styles.overlay}>
 			<div class={styles.modal}>
 				{auth.stage.value === 'EMAIL' ? (<>
+					{needsManualMigration.value ? (
+						<div class={styles.warning}>
+							<strong>Where did my games go?</strong> If you've used Sprig before on this browser, you may want to <a href='/migrate'>migrate your games</a>.
+						</div>
+					) : null}
+
 					<div class={styles.stack}>
 						<h2>Start building right away</h2>
 						<p>

--- a/src/components/popups-etc/migrate-toast.tsx
+++ b/src/components/popups-etc/migrate-toast.tsx
@@ -15,7 +15,7 @@ export default function MigrateToast(props: MigrateToastProps) {
 
 	useEffect(() => {
 		if (localStorage.getItem('seenMigration') !== 'true') {
-			getPuzzleLabFromLocalStorage().then(data => {
+			getPuzzleLabFromLocalStorage(false).then(data => {
 				if (data.length > 0) showPopup.value = true
 			})
 		}

--- a/src/lib/game-saving/legacy-migration.ts
+++ b/src/lib/game-saving/legacy-migration.ts
@@ -1,6 +1,9 @@
-export const getPuzzleLabFromLocalStorage = (): Promise<string> => new Promise((resolve) => {
-	if (window.localStorage.getItem('puzzleLab'))
-		resolve(window.localStorage.getItem('puzzleLab')!)
+export const getPuzzleLabFromLocalStorage = (allowRedirect: boolean): Promise<string> => new Promise((resolve) => {
+	const params = new URLSearchParams(window.location.search)
+	if (params.get('puzzleLab') !== null) return resolve(params.get('puzzleLab')!)
+	
+	// const helperUrl = 'http://localhost:3001/migration-helper.html'
+	const helperUrl = 'https://editor.sprig.hackclub.com/migration-helper.html'
 
 	let iframe: HTMLIFrameElement
 	const listener = (event: MessageEvent<unknown>) => {
@@ -10,15 +13,28 @@ export const getPuzzleLabFromLocalStorage = (): Promise<string> => new Promise((
 		&& event.data.sprig === true
 		&& 'puzzleLab' in event.data
 		&& typeof event.data.puzzleLab === 'string'
+		&& 'storageAccessDenied' in event.data
+		&& typeof event.data.storageAccessDenied === 'boolean'
 		) {
 			if (iframe) iframe.remove()
 			window.removeEventListener('message', listener)
-			resolve(event.data.puzzleLab)
+
+			if (event.data.storageAccessDenied) {
+				if (!allowRedirect) {
+					console.warn('Storage access denied, but a redirect would be bad for UX')
+					return resolve('')
+				}
+				const parsedHelperUrl = new URL(helperUrl)
+				parsedHelperUrl.searchParams.set('redirect', window.location.href.toString())
+				window.location.replace(parsedHelperUrl.toString())
+			} else {
+				resolve(event.data.puzzleLab)
+			}
 		}
 	}
 	window.addEventListener('message', listener)
 	iframe = document.createElement('iframe')
-	iframe.src = 'https://editor.sprig.hackclub.com/migration-helper.html'
+	iframe.src = helperUrl
 	iframe.style.display = 'none'
 	document.body.appendChild(iframe)
 })

--- a/src/lib/game-saving/legacy-migration.ts
+++ b/src/lib/game-saving/legacy-migration.ts
@@ -1,9 +1,20 @@
+import { Signal, useSignal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+	
+// const helperUrl = 'http://localhost:3001/migration-helper.html'
+const helperUrl = 'https://editor.sprig.hackclub.com/migration-helper.html'
+
 export const getPuzzleLabFromLocalStorage = (allowRedirect: boolean): Promise<string> => new Promise((resolve) => {
 	const params = new URLSearchParams(window.location.search)
-	if (params.get('puzzleLab') !== null) return resolve(params.get('puzzleLab')!)
-	
-	// const helperUrl = 'http://localhost:3001/migration-helper.html'
-	const helperUrl = 'https://editor.sprig.hackclub.com/migration-helper.html'
+	if (params.get('puzzleLab') !== null) {
+		// Remove the query param, it's cleaner for the user and means
+		// reloading the page refreshes the localStorage data.
+		const url = new URL(window.location.toString())
+		url.searchParams.delete('puzzleLab')
+		history.replaceState({}, '', url.toString())
+
+		return resolve(params.get('puzzleLab')!)
+	}
 
 	let iframe: HTMLIFrameElement
 	const listener = (event: MessageEvent<unknown>) => {
@@ -20,6 +31,8 @@ export const getPuzzleLabFromLocalStorage = (allowRedirect: boolean): Promise<st
 			window.removeEventListener('message', listener)
 
 			if (event.data.storageAccessDenied) {
+				// document.requestStorageAccess() errored in the frame, we need to
+				// redirect through the helper to get data.
 				if (!allowRedirect) {
 					console.warn('Storage access denied, but a redirect would be bad for UX')
 					return resolve('')
@@ -38,3 +51,36 @@ export const getPuzzleLabFromLocalStorage = (allowRedirect: boolean): Promise<st
 	iframe.style.display = 'none'
 	document.body.appendChild(iframe)
 })
+
+export const useNeedsManualMigration = (): Signal<boolean> => {
+	const needsManualMigration = useSignal(false)
+
+	useEffect(() => {
+		let iframe: HTMLIFrameElement
+		const listener = (event: MessageEvent<unknown>) => {
+			if (event.data
+			&& typeof event.data === 'object'
+			&& 'sprig' in event.data 
+			&& event.data.sprig === true
+			&& 'storageAccessDenied' in event.data
+			&& typeof event.data.storageAccessDenied === 'boolean'
+			) {
+				if (iframe) iframe.remove()
+				window.removeEventListener('message', listener)
+				needsManualMigration.value = event.data.storageAccessDenied
+			}
+		}
+		window.addEventListener('message', listener)
+		iframe = document.createElement('iframe')
+		iframe.src = helperUrl
+		iframe.style.display = 'none'
+		document.body.appendChild(iframe)
+
+		return () => {
+			if (iframe) iframe.remove()
+			window.removeEventListener('message', listener)
+		}
+	}, [])
+
+	return needsManualMigration
+}

--- a/src/lib/game-saving/legacy-migration.ts
+++ b/src/lib/game-saving/legacy-migration.ts
@@ -1,4 +1,4 @@
-import { Signal, useSignal } from '@preact/signals'
+import { type Signal, useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 	
 // const helperUrl = 'http://localhost:3001/migration-helper.html'

--- a/src/pages/~/index.astro
+++ b/src/pages/~/index.astro
@@ -101,7 +101,7 @@ if (games.length === 0 && unnamedGames.length > 0) {
 					<a class='game' href={`/~/${game.id}`}>
 						<h3>{game.name || 'Untitled'}</h3>
 						<p class='modified-at'>
-							Edited {ms(Date.now() - game.modifiedAt.toMillis(), { long: true })} ago
+							Edited {ms(Math.max(Date.now() - game.modifiedAt.toMillis(), 1000), { long: true })} ago
 						</p>
 					</a>
 				))}
@@ -115,7 +115,7 @@ if (games.length === 0 && unnamedGames.length > 0) {
 							<a class='game' href={`/~/${game.id}`}>
 								<h3>{game.name || 'Untitled'}</h3>
 								<p class='modified-at'>
-									Edited {ms(Date.now() - game.modifiedAt.toMillis(), { long: true })} ago
+									Edited {ms(Math.max(Date.now() - game.modifiedAt.toMillis(), 1000), { long: true })} ago
 								</p>
 							</a>
 						))}


### PR DESCRIPTION
Fixes #885. The migration page now redirects through the helper when localStorage access is denied. I also added a warning on the opening modal.