### PR TITLE
Add file player to fix khrj's workflow

### DIFF
--- a/src/pages/deprecated-file-player.astro
+++ b/src/pages/deprecated-file-player.astro
@@ -1,0 +1,63 @@
+---
+import '../global.css'
+import StandardHead from '../components/standard-head.astro'
+
+const file = Astro.url.searchParams.get('file') ?? ''
+const codeRes = await fetch(file)
+const code = await codeRes.text()
+---
+
+<html lang='en'>
+	<head>
+		<StandardHead title='(Deprecated) File Player' />
+		<style>
+			#screen-container {
+				width: 100%;
+				height: 100%;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+			}
+
+			#screen {
+				max-width: 100%;
+				max-height: 100%;
+				background: black;
+			}
+		</style>
+	</head>
+	<body>
+		<div id='screen-container'>
+			<canvas id='screen' width='1000' height='800' tabindex='-1' />
+		</div>
+
+		<script define:vars={{ code }}>
+			window.__sprig_intitial_code__ = code
+		</script>
+		<script>
+			import { runGame } from '../lib/engine/3-editor'
+
+			const screen = document.getElementById('screen') as HTMLCanvasElement
+			const { __sprig_intitial_code__ } = window as unknown as { __sprig_intitial_code__: string }
+			
+			let runRes = runGame(__sprig_intitial_code__, screen, (_) => {})
+			if (runRes.error) console.error(runRes.error.raw)
+			
+			const params = new URLSearchParams(window.location.search)
+			if (params.has('watch')) {
+				let oldCode = __sprig_intitial_code__
+				setInterval(async () => {
+					const codeRes = await fetch(params.get('file') || '')
+					const code = await codeRes.text()
+
+					if (oldCode !== code) {
+						oldCode = code
+						runRes.cleanup()
+						runRes = runGame(code, screen, (_) => {})
+						if (runRes.error) console.error(runRes.error.raw)
+					}
+				}, Number(params.get('watch') || 1000))
+			}
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
This adds a new route, `/deprecated-file-player`, which is a barebones player-only page that autoruns. It supports two URL parameters, `file` to load a file from URL, and `watch` to rerun when the file changes.

@khrj I recognize that this is more barebones than the original PR, but I wonder if this is enough to fix your workflow? If not, please let me know what you need.

Calling it deprecated because I don't want to encourage using this for anything except to un-break existing projects relying on the parameters you added in #644. I'm planning on likely removing this page if we publish an NPM package and make sure everything relying on this migrates over.

When merged this will fix #908.