### PR TITLE
Use the local version of the metadata.json instead of sourcing from github

### DIFF
--- a/src/lib/game-saving/gallery.ts
+++ b/src/lib/game-saving/gallery.ts
@@ -1,3 +1,5 @@
+import metadata from '../../../games/metadata.json'
+
 export interface GameMetadata {
 	filename: string
 	title: string
@@ -8,4 +10,4 @@ export interface GameMetadata {
 	isNew: true | undefined
 }
 
-export const getGalleryGames = async () => await fetch('https://raw.githubusercontent.com/hackclub/sprig/main/games/metadata.json').then((res) => res.json()) as GameMetadata[]
+export const getGalleryGames = () => metadata as GameMetadata[]

--- a/src/pages/gallery/[filename].astro
+++ b/src/pages/gallery/[filename].astro
@@ -27,7 +27,7 @@ let tutorial: string[] | undefined = files
 	?.map(md => md.compiledContent())
 if (tutorial.length == 0) tutorial = undefined
 
-const games = await getGalleryGames()
+const games = getGalleryGames()
 const metadata = games.find(game => game.filename === filename)
 const name = metadata?.title
 const authorName = metadata?.author

--- a/src/pages/gallery/index.astro
+++ b/src/pages/gallery/index.astro
@@ -9,7 +9,7 @@ import Gallery from "./gallery";
 
 const session = await getSession(Astro.cookies);
 
-const games = await getGalleryGames();
+const games = getGalleryGames();
 const tags = [
 	...new Set(games.reduce<string[]>((p, c) => [...p, ...c.tags], [])),
 ];


### PR DESCRIPTION
This change will allow submitted apps to include their own change to the metadata.json which will be reviewed alongside all other things w/ the app.  Thus, the app will actually show up in the gallery such that we can ensure, for instance, the image displays properly.  This also will result in good, public review of the tags and metadata that go along w/ the apps.