### PR TITLE
add infinite loop detection

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -8,6 +8,23 @@ and sharing them with others. You can watch [this video](https://www.youtube.com
 
 Run games by hitting the `Run` button or pressing `Shift+Enter`.
 
+### Infinite loop detection
+The Sprig editor will automatically insert a heuristic in your `for`, `while` and or `do-while` loops to detect potential infinite loops.
+Code looking like
+```js
+while (condition) {
+  // do stuff
+}
+```
+will become
+```js
+startTime = performance.now()
+while (condition) {if (++_loopIt > 2000 && performance.now() - startTime > 1500) throw new RangeError("Potential infinite loop")
+  // do stuff
+}
+```
+Note that all original line numbers in your code will be preserved.
+
 ## Getting Help
 
 If this is your first time using Sprig, try playing through the [tutorial](https://sprig.hackclub.com/gallery/getting_started). From there, we suggest hacking on any of the [current games](https://sprig.hackclub.com/gallery) or starting from scratch.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -8,23 +8,6 @@ and sharing them with others. You can watch [this video](https://www.youtube.com
 
 Run games by hitting the `Run` button or pressing `Shift+Enter`.
 
-### Infinite loop detection
-The Sprig editor will automatically insert a heuristic in your `for`, `while` and or `do-while` loops to detect potential infinite loops.
-Code looking like
-```js
-while (condition) {
-  // do stuff
-}
-```
-will become
-```js
-startTime = performance.now()
-while (condition) {if (++_loopIt > 2000 && performance.now() - startTime > 1500) throw new RangeError("Potential infinite loop")
-  // do stuff
-}
-```
-Note that all original line numbers in your code will be preserved.
-
 ## Getting Help
 
 If this is your first time using Sprig, try playing through the [tutorial](https://sprig.hackclub.com/gallery/getting_started). From there, we suggest hacking on any of the [current games](https://sprig.hackclub.com/gallery) or starting from scratch.
@@ -324,3 +307,20 @@ const tileHasType = (x, y, type) => getTile(x, y).some(s => s.type === type)
 const getTypeFromTile = (x, y, type) => getTile(x, y, type).find(s => s.type === type)
 ```
  -->
+
+## Infinite loop detection
+The Sprig editor will automatically insert a heuristic in your `for`, `while` and or `do-while` loops to detect potential infinite loops.
+Code looking like
+```js
+while (condition) {
+  // do stuff
+}
+```
+will become
+```js
+startTime = performance.now()
+while (condition) {if (++_loopIt > 2000 && performance.now() - startTime > 1500) throw new RangeError("Potential infinite loop")
+  // do stuff
+}
+```
+Note that all original line numbers in your code will be preserved.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
 		"tinykeys": "^1.4.0"
 	},
 	"devDependencies": {
+		"@babel/standalone": "^7.23.8",
 		"@prefresh/vite": "^2.2.9",
+		"@types/babel__standalone": "^7.1.7",
 		"@types/debounce": "^1.2.1",
 		"@types/esprima": "^4.0.3",
 		"@types/grecaptcha": "^3.0.4",

--- a/src/components/big-interactive-pages/editor.tsx
+++ b/src/components/big-interactive-pages/editor.tsx
@@ -18,6 +18,9 @@ import { nanoid } from 'nanoid'
 import TutorialWarningModal from '../popups-etc/tutorial-warning'
 import { isDark } from '../../lib/state'
 
+import * as Babel from "@babel/standalone";
+import TransformDetectInfiniteLoop from '../../lib/transform-detect-infinite-loop'
+
 interface EditorProps {
 	persistenceState: Signal<PersistenceState>
 	cookies: {
@@ -168,8 +171,13 @@ export default function Editor({ persistenceState, cookies }: EditorProps) {
 		errorLog.value = []
 
 		const code = codeMirror.value?.state.doc.toString() ?? ''
-		const res = runGame(code, screen.current, (error) => {
-			errorLog.value = [ ...errorLog.value, error ]
+		const transformResult = Babel.transform(code, {
+			plugins: [ TransformDetectInfiniteLoop ],
+			retainLines: true
+		});
+
+		const res = runGame(transformResult.code!, screen.current, (error) => {
+			errorLog.value = [...errorLog.value, error]
 		})
 
 		screen.current.focus()

--- a/src/lib/transform-detect-infinite-loop.ts
+++ b/src/lib/transform-detect-infinite-loop.ts
@@ -1,8 +1,5 @@
 // Based on https://repl.it/site/blog/infinite-loops by Amjad Masad.
 
-const MAX_ITERATIONS = 2000;
-const MAX_LOOP_TIME_MS = 1500;
-
 /*
 * The infinite loop detection transform will detect infinite loops if the following conditions are met
 * 1. There are more than 2000 iterations in the loop
@@ -12,6 +9,8 @@ const MAX_LOOP_TIME_MS = 1500;
 *       Add new tests if new functionality is added in this infinite-loop detection code
 */
 export default function TransformDetectInfiniteLoop({ types: t }: { types: any }) {
+	const MAX_ITERATIONS = +import.meta.env.PUBLIC_MAX_ITERATIONS;
+	const MAX_LOOP_TIME_MS = +import.meta.env.PUBLIC_MAX_LOOP_TIME_MS;
 	return {
 		visitor: {
 			'WhileStatement|ForStatement|DoWhileStatement': (path: any) => {

--- a/src/lib/transform-detect-infinite-loop.ts
+++ b/src/lib/transform-detect-infinite-loop.ts
@@ -1,0 +1,89 @@
+// Based on https://repl.it/site/blog/infinite-loops by Amjad Masad.
+
+export default function TransformDetectInfiniteLoop({ types: t }) {
+	const MAX_ITERATIONS = 2000;
+	const MAX_LOOP_TIME_MS = 1500;
+
+	return {
+		visitor: {
+			'WhileStatement|ForStatement|DoWhileStatement': (path: any) => {
+				const startTime = t.identifier('startTime');
+				path.scope.parent.push({
+					id: startTime,
+					init: t.numericLiteral(0)
+				});
+
+				// An iterator that is incremented with each iteration
+				const iterator = t.identifier('loopIt');
+				path.scope.parent.push({
+					id: iterator,
+					init: t.numericLiteral(0)
+				});
+
+				// re-initialize counter variable
+				const countReInitializer = t.assignmentExpression('=', t.identifier(iterator.name), t.numericLiteral(0));
+				// re-initialize counter variable for this loop
+				path.insertBefore(t.expressionStatement(countReInitializer));
+
+				// re-initialize time variable
+				// will begin counting execution time from before the loop starts
+				const timeReInitializer = t.assignmentExpression('=', t.identifier('startTime'), t.callExpression(
+					t.identifier('performance.now'),
+					[]
+				));
+				path.insertBefore(t.expressionStatement(timeReInitializer));
+
+
+				/*
+				* throw RangeError if loop
+				* 1. does over MAX_ITERATIONS iterations
+				* 2. takes more than MAX_LOOP_TIME_MS to complete 
+				*/
+				const guard = t.ifStatement(
+					t.logicalExpression(
+						'&&',
+						t.binaryExpression(
+							'>',
+							t.updateExpression(
+								'++',
+								iterator,
+								true,
+							),
+							t.numericLiteral(MAX_ITERATIONS),
+						),
+						t.binaryExpression(
+							'>',
+							t.binaryExpression(
+								'-',
+								t.callExpression(t.identifier('performance.now'), []),
+								startTime
+							),
+							t.numericLiteral(MAX_LOOP_TIME_MS)
+						),
+					),
+					t.throwStatement(
+						t.newExpression(
+							t.identifier('RangeError'),
+							[t.stringLiteral(
+								'Potential infinite loop',
+							)],
+						),
+					),
+				);
+
+				// No block statment e.g. `while (1) 1;`
+				if (!path.get('body').isBlockStatement()) {
+					const statement = path.get('body').node;
+					path.get('body').replaceWith(
+						t.blockStatement([
+							guard,
+							statement,
+						]),
+					);
+				} else {
+					path.get('body').unshiftContainer('body', guard);
+				}
+			}
+		}
+	}
+}

--- a/src/lib/transform-detect-infinite-loop.ts
+++ b/src/lib/transform-detect-infinite-loop.ts
@@ -1,9 +1,17 @@
 // Based on https://repl.it/site/blog/infinite-loops by Amjad Masad.
 
-export default function TransformDetectInfiniteLoop({ types: t }) {
-	const MAX_ITERATIONS = 2000;
-	const MAX_LOOP_TIME_MS = 1500;
+const MAX_ITERATIONS = 2000;
+const MAX_LOOP_TIME_MS = 1500;
 
+/*
+* The infinite loop detection transform will detect infinite loops if the following conditions are met
+* 1. There are more than 2000 iterations in the loop
+* 2. The loop takes over 1.2 seconds to complete
+* 
+* NOTE: Please run the test in tests/inf-loop.test.ts to and make sure they all pass before commiting changes
+*       Add new tests if new functionality is added in this infinite-loop detection code
+*/
+export default function TransformDetectInfiniteLoop({ types: t }: { types: any }) {
 	return {
 		visitor: {
 			'WhileStatement|ForStatement|DoWhileStatement': (path: any) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,6 +488,11 @@
     "@babel/plugin-syntax-jsx" "^7.22.5"
     "@babel/types" "^7.22.15"
 
+"@babel/standalone@^7.23.8":
+  version "7.23.8"
+  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.23.8.tgz#534b991afed6aead40ff925ef465c781bd8f7e77"
+  integrity sha512-i0tPn3dyKHbEZPDV66ry/7baC1pznRU02R8sU6eJSBfTOwMkukRdYuT3ks/j/cvTl4YkHMRmhTejET+iyPZVvQ==
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -1326,6 +1331,17 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@types/babel__core@^7.1.0":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
+  integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
+  dependencies:
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
 "@types/babel__core@^7.20.1":
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.2.tgz#215db4f4a35d710256579784a548907237728756"
@@ -1343,6 +1359,13 @@
   integrity sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@types/babel__standalone@^7.1.7":
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/@types/babel__standalone/-/babel__standalone-7.1.7.tgz#8ab09548a24f54015e7d84a55486148180bc4ace"
+  integrity sha512-4RUJX9nWrP/emaZDzxo/+RYW8zzLJTXWJyp2k78HufG459HCz754hhmSymt3VFOU6/Wy+IZqfPvToHfLuGOr7w==
+  dependencies:
+    "@types/babel__core" "^7.1.0"
 
 "@types/babel__template@*":
   version "7.4.1"


### PR DESCRIPTION
the sprig editor will throw an error if
1. there are more than 2000 iterations in a loop AND
2. the loop takes > 1.5s to complete

<img width="559" alt="image" src="https://github.com/hackclub/sprig/assets/47951376/0227da63-f90a-4cca-a64b-7f7cbe83eb25">


addresses #1091 

add environment variables to Vercel deployment
- [x] `PUBLIC_MAX_ITERATIONS`
- [x] `PUBLIC_MAX_LOOP_TIME_MS`