### PR TITLE
make dark mode sticky acorss relaods

### DIFF
--- a/src/components/big-interactive-pages/editor.tsx
+++ b/src/components/big-interactive-pages/editor.tsx
@@ -130,6 +130,9 @@ export default function Editor({ persistenceState, cookies }: EditorProps) {
 	// Max height
 	const maxOutputAreaSize = useSignal(outputAreaSize.value)
 	useEffect(() => {
+		// load the dark mode value from localstorage
+		isDark.value = Boolean(localStorage.getItem("isDark") ?? "")
+		
 		const updateMaxSize = () => {
 			maxOutputAreaSize.value = (window.innerWidth - outputAreaWidthMargin) / 2.5
 		}

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -93,6 +93,8 @@ export const isDark = signal<boolean>(false)
 
 export const toggleTheme = () => {
 	isDark.value = !isDark.value;
-	// console.log(isDark.value);
-	localStorage.setItem("isDark", isDark.value.toString());
+	
+	// store true as "true" or false as ""
+	// empty strings coerce to false 
+	localStorage.setItem("isDark", isDark.value ? isDark.value.toString() : "");
 } 


### PR DESCRIPTION
addreses #1414 
store the current value of isDark in localStorage
load the value of isDark from localstorage when the editor is rendering