### PR TITLE
add "I'm stuck" tool to sprig editor

### DIFF
--- a/src/components/big-interactive-pages/editor.tsx
+++ b/src/components/big-interactive-pages/editor.tsx
@@ -16,7 +16,7 @@ import { defaultExampleCode } from '../../lib/examples'
 import MigrateToast from '../popups-etc/migrate-toast'
 import { nanoid } from 'nanoid'
 import TutorialWarningModal from '../popups-etc/tutorial-warning'
-import { isDark } from '../../lib/state'
+import { isDark, editSessionLength } from '../../lib/state'
 
 interface EditorProps {
 	persistenceState: Signal<PersistenceState>
@@ -127,6 +127,9 @@ export default function Editor({ persistenceState, cookies }: EditorProps) {
 	// Max height
 	const maxOutputAreaSize = useSignal(outputAreaSize.value)
 	useEffect(() => {
+	  // re-intialize the initial value of the editing session length to since the editor was opened
+		editSessionLength.value = new Date();
+
 		// load the dark mode value from localstorage
 		isDark.value = Boolean(localStorage.getItem("isDark") ?? "")
 

--- a/src/components/big-interactive-pages/editor.tsx
+++ b/src/components/big-interactive-pages/editor.tsx
@@ -127,7 +127,7 @@ export default function Editor({ persistenceState, cookies }: EditorProps) {
 	// Max height
 	const maxOutputAreaSize = useSignal(outputAreaSize.value)
 	useEffect(() => {
-	  // re-intialize the initial value of the editing session length to since the editor was opened
+	  // re-intialize the value of the editing session length to since the editor was opened
 		editSessionLength.value = new Date();
 
 		// load the dark mode value from localstorage

--- a/src/components/design-system/textarea.module.css
+++ b/src/components/design-system/textarea.module.css
@@ -1,0 +1,20 @@
+.textarea {
+	background: #ffffff;
+	border: 2px solid var(--fg-muted);
+	padding: 8px 12px;
+	display: block;
+	font-size: 0.9rem;
+	font-family: inherit;
+	outline: none;
+	width: 100%;
+	line-height: 1.2;
+}
+
+.textarea:focus {
+	border-color: var(--bg-btn-inactive);
+}
+
+.textarea::placeholder {
+	color: var(--fg-muted);
+	user-select: none;
+}

--- a/src/components/design-system/textarea.tsx
+++ b/src/components/design-system/textarea.tsx
@@ -1,0 +1,27 @@
+import { Signal } from "@preact/signals";
+import styles from "./textarea.module.css"
+
+interface TextareaProps {
+	id?: string
+	placeholder?: string
+	class?: string | undefined
+	onChange: (event: any) => void
+	value: string
+	cols?: number
+	rows?: number
+	bind?: Signal<string>
+}
+
+export default function Textarea(props: TextareaProps) {
+	return (
+		<textarea
+			id={props.id ?? ""}
+			class={`${styles.textarea} ${props.class ?? ""}`}
+			value={props.value}
+			onChange={props.onChange}
+			placeholder={props.placeholder ?? ""}
+			cols={props.cols ?? 30}
+			rows={props.rows ?? 30}
+		 />
+	)
+}

--- a/src/components/design-system/textarea.tsx
+++ b/src/components/design-system/textarea.tsx
@@ -21,7 +21,7 @@ export default function Textarea(props: TextareaProps) {
 			onChange={props.onChange}
 			placeholder={props.placeholder ?? ""}
 			cols={props.cols ?? 30}
-			rows={props.rows ?? 30}
+			rows={props.rows ?? 10}
 		 />
 	)
 }

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -1,5 +1,5 @@
 import { Signal, useSignal, useSignalEffect } from '@preact/signals'
-import { codeMirror, PersistenceState, isDark, toggleTheme } from '../lib/state'
+import { codeMirror, PersistenceState, isDark, toggleTheme, errorLog } from '../lib/state'
 import Button from './design-system/button'
 import Input from './design-system/input'
 import Textarea from './design-system/textarea'
@@ -65,7 +65,7 @@ type StuckData = {
 export default function EditorNavbar(props: EditorNavbarProps) {
 	const showNavPopup = useSignal(false)
 	const showStuckPopup = useSignal(false)
-	
+
 	const stuckData = useSignal<StuckData>({
 		name: "",
 		category: "Other" as any,
@@ -145,7 +145,7 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 					</>) : props.persistenceState.value.kind === 'SHARED' ? (<>
 						{props.persistenceState.value.name}
 						<span class={styles.attribution}>
-							{props.persistenceState.value.authorName 
+							{props.persistenceState.value.authorName
 								? ` by ${props.persistenceState.value.authorName}`
 								: ' (shared with you)'}
 						</span>
@@ -213,13 +213,14 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 					event.preventDefault();
 					const payload = {
 						code: codeMirror.value?.state.doc.toString(),
+						error: errorLog.value,
 						...stuckData.value
 					};
 					const response = await fetch("/api/stuck-request", {
 						method: "POST",
 						body: JSON.stringify(payload)
 					})
-					if (response.ok) alert("We received your request. We'll get back to you in a bit.") 
+					if (response.ok) alert("We received your request. We'll get back to you in a bit.")
 				}}>
 					<label htmlFor="slack username">What is your slack username?</label>
 					<Input value={stuckData.value.name} onChange={(event) => {

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -227,7 +227,9 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 					})
 
 					// Let the user know we'll get back to them after we've receive their complaint
-					if (response.ok) alert("We received your request. We'll get back with help within a week.")
+					if (response.ok) {
+					   alert("We received your request. We'll get back with help within a week.")
+					} else alert("We couldn't send your request. Please make sure you're connected and try again.")
 				}}>
 					<label htmlFor="slack username">What is your slack username?</label>
 					<Input value={stuckData.value.name} onChange={(event) => {

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -208,10 +208,18 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 
 		{showStuckPopup.value && (
 			<div class={styles.stuckPopup}>
-				<form onSubmit={(event) => {
+				<form onSubmit={async (event) => {
 					// do some airtable shenanigans here :D
 					event.preventDefault();
-					console.log(stuckData.value);
+					const payload = {
+						code: codeMirror.value?.state.doc.toString(),
+						...stuckData.value
+					};
+					const response = await fetch("/api/stuck-request", {
+						method: "POST",
+						body: JSON.stringify(payload)
+					})
+					if (response.ok) alert("We received your request. We'll get back to you in a bit.") 
 				}}>
 					<label htmlFor="slack username">What is your slack username?</label>
 					<Input value={stuckData.value.name} onChange={(event) => {

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -213,7 +213,9 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 
 					// Store a copy of the user's code, currently active errors and the length of their editing session
 					// along with their description of the issue
+					const selectionRange = codeMirror.value?.state.selection.ranges[0] ?? { from: -1, to: -1 };
 					const payload = {
+					  selection: JSON.stringify({ from: selectionRange.from, to: selectionRange.to }),
 					  email: props.persistenceState.value.session?.user.email,
 						code: codeMirror.value?.state.doc.toString(),
 						error: errorLog.value,

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -228,7 +228,7 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 
 					// Let the user know we'll get back to them after we've receive their complaint
 					if (response.ok) {
-					   alert("We received your request. We'll get back with help within a week.")
+					   alert("We received your request. We'll get back to you on Slack within a week.")
 					} else alert("We couldn't send your request. Please make sure you're connected and try again.")
 				}}>
 					<label htmlFor="slack username">What is your slack username?</label>

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -234,7 +234,7 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 
 					// Let the user know we'll get back to them after we've receive their complaint
 					if (response.ok) {
-					   alert("We received your request. We'll get back to you via email within a week.")
+					   alert("We received your request and will get back to.")
 					} else alert("We couldn't send your request. Please make sure you're connected and try again.")
 				}}>
 					<label htmlFor="issue category">What is the type of issue you're facing?</label>

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -1,5 +1,5 @@
 import { Signal, useSignal, useSignalEffect } from '@preact/signals'
-import { codeMirror, PersistenceState, isDark, toggleTheme, errorLog } from '../lib/state'
+import { codeMirror, PersistenceState, isDark, toggleTheme, errorLog, editSessionLength } from '../lib/state'
 import Button from './design-system/button'
 import Input from './design-system/input'
 import Textarea from './design-system/textarea'
@@ -214,6 +214,7 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 					const payload = {
 						code: codeMirror.value?.state.doc.toString(),
 						error: errorLog.value,
+						sessionLength: (new Date().getTime() - editSessionLength.value.getTime()) / 1000, // calculate the session length in seconds
 						...stuckData.value
 					};
 					const response = await fetch("/api/stuck-request", {

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -213,6 +213,7 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 
 					// 'from' and 'to' represent the index of character where the selection is started to where it's ended
 					// if 'from' and 'to' are equal, then it's the cursor position
+					// from && to being -1 means the cursor is not in the editor
 					const selectionRange = codeMirror.value?.state.selection.ranges[0] ?? { from: -1, to: -1 };
 
 					// Store a copy of the user's code, currently active errors and the length of their editing session

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -85,7 +85,9 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 		if (!_showNavPopup && _resetState === 'confirm') resetState.value = 'idle'
 	})
 
+	// usePopupCloseClick closes a popup when you click outside of its area
 	usePopupCloseClick(styles.navPopup!, () => showNavPopup.value = false, showNavPopup.value)
+	usePopupCloseClick(styles.stuckPopup!, () => showStuckPopup.value = false, showStuckPopup.value)
 
 	let saveState
 	let actionButton
@@ -161,9 +163,7 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 			</li>
 
 			<li>
-				<Button class={styles.stuckBtn} onClick={() => {
-					showStuckPopup.value = !showStuckPopup.value;
-				}}>
+				<Button class={styles.stuckBtn} onClick={() => showStuckPopup.value = !showStuckPopup.value}>
 					I'm stuck
 				</Button>
 			</li>

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -208,7 +208,7 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 
 		{showStuckPopup.value && (
 			<div class={styles.stuckPopup}>
-				<form onSubmit={async (event) => {
+				<form class={styles.stuckForm} onSubmit={async (event) => {
 					// do some airtable shenanigans here :D
 					event.preventDefault();
 					const payload = {

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -211,9 +211,12 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 				<form class={styles.stuckForm} onSubmit={async (event) => {
 					event.preventDefault(); // prevent the browser from reloading after form submit
 
+					// 'from' and 'to' represent the index of character where the selection is started to where it's ended
+					// if 'from' and 'to' are equal, then it's the cursor position
+					const selectionRange = codeMirror.value?.state.selection.ranges[0] ?? { from: -1, to: -1 };
+
 					// Store a copy of the user's code, currently active errors and the length of their editing session
 					// along with their description of the issue
-					const selectionRange = codeMirror.value?.state.selection.ranges[0] ?? { from: -1, to: -1 };
 					const payload = {
 					  selection: JSON.stringify({ from: selectionRange.from, to: selectionRange.to }),
 					  email: props.persistenceState.value.session?.user.email,

--- a/src/components/navbar.module.css
+++ b/src/components/navbar.module.css
@@ -158,6 +158,17 @@
 	background-color: rgb(255, 66, 66);
 }
 
+.stuckForm label {
+	margin: 0.5em 0;
+}
+.stuckForm input, .stuckForm textarea {
+	margin-bottom: 0.5em;
+}
+
+.stuckForm button {
+	justify-content: center;
+}
+
 /* Transparency! */
 .transparent {
 	background: transparent;

--- a/src/components/navbar.module.css
+++ b/src/components/navbar.module.css
@@ -154,6 +154,10 @@
 	width: 24px;
 }
 
+.stuckBtn {
+	background-color: rgb(255, 66, 66);
+}
+
 /* Transparency! */
 .transparent {
 	background: transparent;
@@ -170,6 +174,39 @@
 .transparent .plainLink a:not(:hover) {
 	display: block;
 	color: var(--fg-muted);
+}
+
+/* Nav popup */
+.stuckPopup {
+	background: var(--accent-dark);
+	color: #ffffff;
+	z-index: 9;
+	position: absolute;
+	top: 48px;
+	right: 25vw;
+	padding: 8px;
+	box-shadow: 0 4px 8px 0 #0000005e;
+	min-width: 160px;
+}
+
+.stuckPopup form {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-evenly;
+}
+
+.stuckPopup .divider {
+	height: 2px;
+	background: var(--accent);
+	margin: 8px 0;
+}
+
+.stuckPopup ul {
+	list-style-type: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
 }
 
 /* Nav popup */

--- a/src/global.css
+++ b/src/global.css
@@ -121,3 +121,20 @@ a:hover {
 .grecaptcha-badge {
 	visibility: hidden;
 }
+
+select {
+	line-height: 1.2;
+	background: var(--bg-btn-inactive);
+	background: white;
+	color: var(--bg-btn-inactive);
+	border: 2px solid var(--bg-btn-inactive);
+	padding: 8px 12px;
+	padding-right: 20px;
+	appearance: none;
+	display: block;
+	font-size: 0.9rem;
+	font-family: inherit;
+	outline: none;
+	width: 100%;
+	user-select: none;
+}

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -88,13 +88,13 @@ export const muted = signal<boolean>(false)
 export const errorLog = signal<NormalizedError[]>([])
 export const openEditor = signal<OpenEditor | null>(null)
 export const bitmaps = signal<[string, string][]>([])
-// export const isDark = signal<boolean>(localStorage.getItem("isDark") == "true");
 export const isDark = signal<boolean>(false)
+export const editSessionLength = signal<Date>(new Date());
 
 export const toggleTheme = () => {
 	isDark.value = !isDark.value;
-	
+
 	// store true as "true" or false as ""
-	// empty strings coerce to false 
+	// empty strings coerce to false
 	localStorage.setItem("isDark", isDark.value ? isDark.value.toString() : "");
-} 
+}

--- a/src/pages/api/stuck-request.ts
+++ b/src/pages/api/stuck-request.ts
@@ -17,6 +17,7 @@ export const post: APIRoute = async ({ request }) => {
 					fields: {
 						"Slack Username": payload.name,
 						"Error Log": JSON.stringify(payload.error),
+						"Session Length": payload.sessionLength,
 						Code: payload.code,
 						Category: payload.category,
 						Description: payload.description

--- a/src/pages/api/stuck-request.ts
+++ b/src/pages/api/stuck-request.ts
@@ -30,6 +30,6 @@ export const post: APIRoute = async ({ request }) => {
 		})
 	});
 
-	const records = await response.json();
-	return new Response(records)
+	const data = await response.json();
+	return new Response(data, { status: response.status })
 }

--- a/src/pages/api/stuck-request.ts
+++ b/src/pages/api/stuck-request.ts
@@ -16,6 +16,7 @@ export const post: APIRoute = async ({ request }) => {
 				{
 					fields: {
 						"Slack Username": payload.name,
+						"Error Log": JSON.stringify(payload.error),
 						Code: payload.code,
 						Category: payload.category,
 						Description: payload.description

--- a/src/pages/api/stuck-request.ts
+++ b/src/pages/api/stuck-request.ts
@@ -18,7 +18,7 @@ export const post: APIRoute = async ({ request }) => {
 			records: [
 				{
 					fields: {
-						"Slack Username": payload.name,
+						Email: payload.email,
 						"Error Log": JSON.stringify(payload.error),
 						"Session Length": payload.sessionLength,
 						Code: payload.code,
@@ -31,5 +31,5 @@ export const post: APIRoute = async ({ request }) => {
 	});
 
 	const data = await response.json();
-	return new Response(data, { status: response.status })
+	return new Response(JSON.stringify(data), { status: response.status })
 }

--- a/src/pages/api/stuck-request.ts
+++ b/src/pages/api/stuck-request.ts
@@ -1,0 +1,30 @@
+import { APIRoute } from "astro"
+
+
+export const post: APIRoute = async ({ request }) => {
+	const AIRTABLE_PAT = process.env.AIRTABLE_TOKEN;
+	const AIRTABLE_BASE = process.env.STUCK_AIRTABLE_BASE;
+	const payload = await request.json();
+	const response = await fetch(`https://api.airtable.com/v0/${AIRTABLE_BASE}/Stuck%20Data`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${AIRTABLE_PAT}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			records: [
+				{
+					fields: {
+						"Slack Username": payload.name,
+						Code: payload.code,
+						Category: payload.category,
+						Description: payload.description
+					}
+				}
+			]
+		})
+	});
+
+	const records = await response.json();
+	return new Response(records)
+}

--- a/src/pages/api/stuck-request.ts
+++ b/src/pages/api/stuck-request.ts
@@ -18,6 +18,7 @@ export const post: APIRoute = async ({ request }) => {
 			records: [
 				{
 					fields: {
+					  Selection: payload.selection,
 						Email: payload.email,
 						"Error Log": JSON.stringify(payload.error),
 						"Session Length": payload.sessionLength,

--- a/src/pages/api/stuck-request.ts
+++ b/src/pages/api/stuck-request.ts
@@ -2,9 +2,12 @@ import { APIRoute } from "astro"
 
 
 export const post: APIRoute = async ({ request }) => {
-	const AIRTABLE_PAT = process.env.AIRTABLE_TOKEN;
-	const AIRTABLE_BASE = process.env.STUCK_AIRTABLE_BASE;
+	const AIRTABLE_PAT = process.env.AIRTABLE_TOKEN; // get the airtable base personal access token
+	const AIRTABLE_BASE = process.env.STUCK_AIRTABLE_BASE; // get the airtable base id
+
 	const payload = await request.json();
+
+	// create a new record in airtable with the payload data
 	const response = await fetch(`https://api.airtable.com/v0/${AIRTABLE_BASE}/Stuck%20Data`, {
 		method: "POST",
 		headers: {


### PR DESCRIPTION
addresses #1433 

This adds a new UI element in the editor where Sprig users can report when they're stuck
<img width="455" alt="image" src="https://github.com/hackclub/sprig/assets/47951376/c11e3845-df32-4735-95ac-0b2717449396">

Once they click "Send", their reports will be stored in an airtable base
![image (5)](https://github.com/hackclub/sprig/assets/47951376/9ef149c4-3db1-4903-a8c9-bd88360d7566)


...and sent through the `#playing-contact-points` slack channel where Slacker would be able to pick it up as an action item

A message looks like this 
<img width="380" alt="image" src="https://github.com/hackclub/sprig/assets/47951376/cd33c29a-43f0-4f64-996b-3f95345d20b5">
Examples: 
<img width="790" alt="image" src="https://github.com/hackclub/sprig/assets/47951376/44fcfc65-8dc9-423a-8e4c-1d2d6121ded2">


### Prerequisites for deployment
- [x] Create an airtable base with the columns as in the screenshot above 
- [x] set AIRTABLE_TOKEN on Vercel production
- [x] set STUCK_AIRTABLE_BASE on Vercel production
- [x] choose/create a slack channel where the Airtable messages would be sent
- [ ] Create Slacker config for listening to these action items