### PR TITLE
move infinite loop detection to after parsing

### DIFF
--- a/src/components/big-interactive-pages/editor.tsx
+++ b/src/components/big-interactive-pages/editor.tsx
@@ -18,9 +18,6 @@ import { nanoid } from 'nanoid'
 import TutorialWarningModal from '../popups-etc/tutorial-warning'
 import { isDark } from '../../lib/state'
 
-import * as Babel from "@babel/standalone";
-import TransformDetectInfiniteLoop from '../../lib/transform-detect-infinite-loop'
-
 interface EditorProps {
 	persistenceState: Signal<PersistenceState>
 	cookies: {
@@ -132,7 +129,7 @@ export default function Editor({ persistenceState, cookies }: EditorProps) {
 	useEffect(() => {
 		// load the dark mode value from localstorage
 		isDark.value = Boolean(localStorage.getItem("isDark") ?? "")
-		
+
 		const updateMaxSize = () => {
 			maxOutputAreaSize.value = (window.innerWidth - outputAreaWidthMargin) / 2.5
 		}
@@ -174,12 +171,7 @@ export default function Editor({ persistenceState, cookies }: EditorProps) {
 		errorLog.value = []
 
 		const code = codeMirror.value?.state.doc.toString() ?? ''
-		const transformResult = Babel.transform(code, {
-			plugins: [ TransformDetectInfiniteLoop ],
-			retainLines: true
-		});
-
-		const res = runGame(transformResult.code!, screen.current, (error) => {
+		const res = runGame(code, screen.current, (error) => {
 			errorLog.value = [...errorLog.value, error]
 		})
 
@@ -191,12 +183,7 @@ export default function Editor({ persistenceState, cookies }: EditorProps) {
 		if (res.error) {
 			console.error(res.error.raw)
 			errorLog.value = [ ...errorLog.value, res.error ]
-			if (res.error.line) {
-				highlightError(res.error.line);
-			}
-		} else {
-			clearErrorHighlight();
-		}		
+		}
 	}
 
 	const onStop = async () => {
@@ -312,7 +299,7 @@ export default function Editor({ persistenceState, cookies }: EditorProps) {
 					<Button accent icon={IoPlayCircleOutline} bigIcon iconSide='right' class={styles.playButton} onClick={onRun}>
 						Run
 					</Button>
-					
+
 				</div>
 
 				<div

--- a/src/lib/engine/index.ts
+++ b/src/lib/engine/index.ts
@@ -5,6 +5,8 @@ import { bitmaps, NormalizedError } from '../state'
 import type { PlayTuneRes } from 'sprig'
 import { textToTune } from 'sprig/base'
 import { webEngine } from 'sprig/web'
+import * as Babel from "@babel/standalone"
+import TransformDetectInfiniteLoop from '../transform-detect-infinite-loop'
 
 interface RunResult {
 	error: NormalizedError | null
@@ -13,7 +15,7 @@ interface RunResult {
 
 export function runGame(code: string, canvas: HTMLCanvasElement, onPageError: (error: NormalizedError) => void): RunResult {
 	const game = webEngine(canvas)
-	
+
 	const tunes: PlayTuneRes[] = []
 	const timeouts: number[] = []
 	const intervals: number[] = []
@@ -22,7 +24,7 @@ export function runGame(code: string, canvas: HTMLCanvasElement, onPageError: (e
 		onPageError(normalizeGameError({ kind: 'page', error: event.error }))
 	}
 	window.addEventListener('error', errorListener)
-	
+
 	const cleanup = () => {
 		game.cleanup()
 		tunes.forEach(tune => tune.end())
@@ -65,7 +67,7 @@ export function runGame(code: string, canvas: HTMLCanvasElement, onPageError: (e
 				return {
 					error: {
 						description: errorString,
-						raw: errorString, 
+						raw: errorString,
 						line: item.loc!.start.line - 1,
 						column: item.loc!.start.column as number
 				}, cleanup };
@@ -77,9 +79,14 @@ export function runGame(code: string, canvas: HTMLCanvasElement, onPageError: (e
 			cleanup
 		}
 	}
-	
+
+	const transformResult = Babel.transform(code, {
+	 plugins: [TransformDetectInfiniteLoop],
+		retainLines: true
+	})
+
 	try {
-		const fn = new Function(...engineAPIKeys, code)
+		const fn = new Function(...engineAPIKeys, transformResult.code!)
 		fn(...Object.values(api))
 		return { error: null, cleanup }
 	} catch (error) {
@@ -109,6 +116,6 @@ export function runGameHeadless(code: string): void {
 		const fn = new Function(...Object.keys(api), code)
 		fn(...Object.values(api))
 	} catch {}
-	
+
 	game.cleanup()
 }


### PR DESCRIPTION
due to the location of the infinite loop detection code, some babel parse errors would not be bubbled up into the editor

this addresses #1426 