### PR TITLE
upgrade esprima to esprima-next and fixing spread operator not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@sendgrid/mail": "^7.7.0",
 		"astro": "2.7.0",
 		"dotenv": "^16.3.1",
-		"esprima": "^4.0.1",
+		"esprima-next": "^6.0.2",
 		"firebase-admin": "^11.10.1",
 		"ms": "^2.1.3",
 		"nanoid": "^4.0.1",

--- a/src/lib/engine/index.ts
+++ b/src/lib/engine/index.ts
@@ -1,5 +1,5 @@
 import { playTune } from './tune'
-import { parseScript } from 'esprima'
+import { parseScript } from "esprima-next"
 import { normalizeGameError, type EsprimaError } from './error'
 import { bitmaps, NormalizedError } from '../state'
 import type { PlayTuneRes } from 'sprig'
@@ -74,6 +74,7 @@ export function runGame(code: string, canvas: HTMLCanvasElement, onPageError: (e
 			}
 		}
 	} catch (error) {
+	  console.log("esprima error", error)
 		return {
 			error: normalizeGameError({ kind: 'parse', error: error as EsprimaError }),
 			cleanup

--- a/src/lib/engine/index.ts
+++ b/src/lib/engine/index.ts
@@ -74,7 +74,6 @@ export function runGame(code: string, canvas: HTMLCanvasElement, onPageError: (e
 			}
 		}
 	} catch (error) {
-	  console.log("esprima error", error)
 		return {
 			error: normalizeGameError({ kind: 'parse', error: error as EsprimaError }),
 			cleanup

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,6 +2443,11 @@ espree@^9.0.0:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.3.0"
 
+esprima-next@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/esprima-next/-/esprima-next-6.0.2.tgz#4a93368e7b0eed803ee9322920b43cadad6f201e"
+  integrity sha512-2qIj1i/S5nK4piHwMY5NfYpcllx0PzDbILbb5+x6Wj6uj5+vNLgezGQeAqW0QVqaMFmJAcSnvFV/xaRXUKVtjQ==
+
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"


### PR DESCRIPTION
The `esprima` package has a bug where the spread operator does not work properly on objects (as described in [this issue](https://github.com/jquery/esprima/issues/2034)). There is a fork called [`esprima-next`](https://github.com/node-projects/esprima-next) where this issue is fixed. 