### PR TITLE
Introduce Auto-Format to Sprig Editor  #1399

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"dotenv": "^16.3.1",
 		"esprima-next": "^6.0.2",
 		"firebase-admin": "^11.10.1",
+		"js-beautify": "^1.15.1",
 		"ms": "^2.1.3",
 		"nanoid": "^4.0.1",
 		"node-statsd": "^0.1.1",

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -13,6 +13,7 @@ import { usePopupCloseClick } from '../lib/utils/popup-close-click'
 import { upload, uploadState } from '../lib/upload'
 import { VscLoading } from 'react-icons/vsc'
 import { defaultExampleCode } from '../lib/examples'
+import { js_beautify } from 'js-beautify';
 
 const saveName = throttle(500, async (gameId: string, newName: string) => {
 	try {
@@ -57,6 +58,34 @@ type StuckData = {
 	description: string
 }
 
+const stripWhitespaceAndUpdate = () => {
+    if (!codeMirror.value) return;
+
+    const currentText = codeMirror.value.state.doc.toString();
+
+    const beautifyOptions = {
+        indent_size: 2,
+        space_in_empty_paren: true,
+        e4x: true,
+        end_with_newline: true,
+        wrap_line_length: 0,
+        preserve_newlines: false,
+        max_preserve_newlines: 2,
+        jslint_happy: false,
+        brace_style: "end-expand",
+        keep_array_indentation: false,
+        keep_function_indentation: false,
+        space_after_anon_function: true
+    };
+
+    const formattedText = js_beautify(currentText, beautifyOptions);
+
+    const updateTransaction = codeMirror.value.state.update({
+        changes: { from: 0, to: codeMirror.value.state.doc.length, insert: formattedText }
+    });
+
+    codeMirror.value.dispatch(updateTransaction);
+};
 export default function EditorNavbar(props: EditorNavbarProps) {
 	const showNavPopup = useSignal(false)
 	const showStuckPopup = useSignal(false)
@@ -298,6 +327,7 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 					</>)}
 				<li><a href='/gallery'>Gallery</a></li>
 				<li><a href='/get'>Get a Sprig</a></li>
+				<li><a href='javascript:void' role='button' onClick={stripWhitespaceAndUpdate}>Prettify code</a></li>
 			</ul>
 			<div class={styles.divider} />
 			<ul>

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -59,31 +59,33 @@ type StuckData = {
 }
 
 const stripWhitespaceAndUpdate = () => {
+    // Check if the CodeMirror editor is empty to avoid unnecessary processing
     if (!codeMirror.value) return;
 
+    // Retrieve the current text from the CodeMirror editor
     const currentText = codeMirror.value.state.doc.toString();
 
+    // Configuration options for beautifying JavaScript code
     const beautifyOptions = {
-        indent_size: 2,
-        space_in_empty_paren: true,
-        e4x: true,
-        end_with_newline: true,
-        wrap_line_length: 0,
-        preserve_newlines: false,
-        max_preserve_newlines: 2,
-        jslint_happy: false,
-        brace_style: "end-expand",
-        keep_array_indentation: false,
-        keep_function_indentation: false,
-        space_after_anon_function: true
+        indent_size: 2, // Sets indentation to 2 spaces for readability
+        space_in_empty_paren: true, // Adds a space inside empty parentheses for clarity
+        end_with_newline: true, // Ensures the file ends with a newline, a common coding standard
+        wrap_line_length: 0, // No wrapping, to avoid breaking code into unintended lines
+        preserve_newlines: false, // Removes extra newlines to tidy up the code
+        max_preserve_newlines: 2, // Limits consecutive newlines to 2 for spacing consistency
+        brace_style: "end-expand", // Places closing braces on a new line for blocks, improving readability
+        space_after_anon_function: true, // Adds a space after anonymous function declarations
     };
 
+    // Beautify the current text using the configured options
     const formattedText = js_beautify(currentText, beautifyOptions);
 
+    // Update the CodeMirror editor with the beautified text
     const updateTransaction = codeMirror.value.state.update({
         changes: { from: 0, to: codeMirror.value.state.doc.length, insert: formattedText }
     });
 
+    // Apply the update to the editor
     codeMirror.value.dispatch(updateTransaction);
 };
 export default function EditorNavbar(props: EditorNavbarProps) {

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -58,7 +58,7 @@ type StuckData = {
 	description: string
 }
 
-const stripWhitespaceAndUpdate = () => {
+const prettifyCode = () => {
     // Check if the CodeMirror editor is empty to avoid unnecessary processing
     if (!codeMirror.value) return;
 
@@ -329,7 +329,7 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 					</>)}
 				<li><a href='/gallery'>Gallery</a></li>
 				<li><a href='/get'>Get a Sprig</a></li>
-				<li><a href='javascript:void' role='button' onClick={stripWhitespaceAndUpdate}>Prettify code</a></li>
+				<li><a href='javascript:void' role='button' onClick={prettifyCode}>Prettify code</a></li>
 			</ul>
 			<div class={styles.divider} />
 			<ul>


### PR DESCRIPTION
### **Introduction**
This pull request introduces an Auto-Format feature to the editor, aimed at improving code readability and consistency. The motivation behind this feature is to provide an easy-to-access tool for users, especially beginners and those participating in hackathons, to automatically format their code. This addresses the common issue of inconsistent code styling, such as indentation and spacing, making the codebase cleaner and easier to read.

### **Changes Made**
Added **stripWhitespaceAndUpdate** function to include js-beautify options.
Added a menu item "Prettify code" in the dropdown, linked to the updated function.

### **Before & After**

**Before: Code that's a bit all over the place.**

![image](https://github.com/hackclub/sprig/assets/34939959/b13ec3da-5c49-4b33-948d-d0a591a2acf3)

**After: Nicely formatted code that's easy on the eyes.**

![image](https://github.com/hackclub/sprig/assets/34939959/83ec9264-a87c-4e95-9888-6cba6ccfef6d)

![image](https://github.com/hackclub/sprig/assets/34939959/2376abd0-f8b5-4033-beaa-3c4851fa633d)
