### PR TITLE
Remove extra scrollbar in help pane

### DIFF
--- a/src/components/popups-etc/help.module.css
+++ b/src/components/popups-etc/help.module.css
@@ -52,7 +52,7 @@
 	border: 2px solid var(--accent);
 	padding: 10px;
 	width: 100%;
-	overflow: scroll;
+	overflow-y: scroll;
 	height: 100%;
 	box-shadow: 0 0 20px 0 #00000038;
 	display: inline-block;
@@ -132,7 +132,7 @@
 	border: 2px solid var(--accent);
 	padding: 10px;
 	width: 100%;
-	overflow: scroll;
+	overflow-y: scroll;
 	height: 100%;
 	box-shadow: 0 0 20px 0 #00000038;
 	display: inline-block;


### PR DESCRIPTION
This isn't a game! (I'm still making mine!)

It's a small fix for a visual thing I recently dealt with in HCB. `overflow: scroll` also adds a horizontal scrollbar, so I've changed it to `overflow-y: scroll`.

Before:
<img width="317" alt="image" src="https://github.com/hackclub/sprig/assets/76178582/9cfe6e13-96d7-4d41-86f9-5d6cf9f0e534">

After:
<img width="324" alt="image" src="https://github.com/hackclub/sprig/assets/76178582/8c72a08c-bcad-45c3-8d02-0f2b56e71ac4">
