### PR TITLE
Link fix on home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -244,8 +244,8 @@ if (session && session.session.full) {
 					Sprig is open-source. Read code for:
 					<a href='https://github.com/hackclub/sprig' target='_blank' rel='noopener'>editor</a>,
 					<a href='https://github.com/hackclub/sprig-engine' target='_blank' rel='noopener'>engine</a>,
-					<a href='https://github.com/hackclub/spade' target='_blank' rel='noopener'>firmware</a>,
-					<a href='https://github.com/hackclub/sprig-hardware' target='_blank' rel='noopener'>hardware</a>
+					<a href='https://github.com/hackclub/sprig/tree/main/firmware/spade' target='_blank' rel='noopener'>firmware</a>,
+					<a href='https://github.com/hackclub/sprig/tree/main/hardware' target='_blank' rel='noopener'>hardware</a>
 				</p>
 
 				<div class='stories'>


### PR DESCRIPTION
Fixed the links to the hardware and firmware. Before they led to a depreciated repo now they lead to this maintained repo.