### PR TITLE
feat: create announcement banner for penny game jam

### DIFF
--- a/src/components/navbar-main.tsx
+++ b/src/components/navbar-main.tsx
@@ -42,6 +42,9 @@ export default function MainNavbar(props: MainNavbarProps) {
 					<a href="/get">Get a Sprig</a>
 				</li>
 			</ul>
+			<div class={styles.desktop}>
+				<AnnouncementBanner />
+			</div>
 			<ul class={styles.rightActions}>
 				{props.session?.session.full ? (
 					<>

--- a/src/components/popups-etc/announcement-banner.module.css
+++ b/src/components/popups-etc/announcement-banner.module.css
@@ -8,9 +8,9 @@
 }
 
 @media (max-width: 800px) {
-  .banner {
-    display: none;
-  }
+	.banner {
+		display: none;
+	}
 }
 
 .banner > a {
@@ -18,10 +18,10 @@
 	align-items: center;
 	display: flex;
 	gap: 14px;
-	background-color: rgba(255, 255, 255, 0.2);
+	background-color: #ffaf07;
 	border-radius: 1rem;
 	width: fit-content;
-	padding: 0 1rem;
+	padding: 1rem;
 	transition: all 0.1s;
 	max-width: 400px;
 }
@@ -37,5 +37,3 @@
 .icon {
 	font-size: 5rem;
 }
-
-

--- a/src/components/popups-etc/announcement-banner.module.css
+++ b/src/components/popups-etc/announcement-banner.module.css
@@ -23,7 +23,7 @@
 	width: fit-content;
 	padding: 1rem;
 	transition: all 0.1s;
-	max-width: 400px;
+	max-width: 500px;
 }
 
 .banner:hover {

--- a/src/components/popups-etc/announcement-banner.tsx
+++ b/src/components/popups-etc/announcement-banner.tsx
@@ -25,8 +25,7 @@ export default function AnnouncementBanner() {
 							fontSize: "14px",
 						}}
 					>
-						Make a Sprig game and receive a free copy of Penny's Big
-						Breakaway!
+						Make a game and receive a copy of Penny's Big Breakaway!
 					</p>
 				</div>
 			</a>

--- a/src/components/popups-etc/announcement-banner.tsx
+++ b/src/components/popups-etc/announcement-banner.tsx
@@ -3,12 +3,32 @@ import styles from "./announcement-banner.module.css";
 export default function AnnouncementBanner() {
 	return (
 		<div class={styles.banner}>
-			<a href="https://sprig-drop.hackclub.com/">
-				<img src="https://cloud-1h9ytxva8-hack-club-bot.vercel.app/0whitesnoman.png" alt="Lil Snoman" width="64" height="75" />
-				<p>
-					SHAWN X SPRIG winter case drops dec-15! click here to learn
-					more about how you can get one!
-				</p>
+			<a href="https://sprig.hackclub.com/share/nSkVqpI6YoUOqDTQW9fV/">
+				<img
+					src="https://cloud-7jnwcp68c-hack-club-bot.vercel.app/0image.png"
+					alt="Penny"
+					width={50}
+					height={50}
+				/>
+				<div>
+					<h3
+						style={{
+							color: "#3e29ed",
+							textAlign: "left",
+						}}
+					>
+						Sprig X Penny's Big Breakaway
+					</h3>
+					<p
+						style={{
+							textAlign: "left",
+							fontSize: "14px",
+						}}
+					>
+						Make a Sprig game and receive a free copy of Penny's Big
+						Breakaway!
+					</p>
+				</div>
 			</a>
 		</div>
 	);


### PR DESCRIPTION
Adds an announcement banner to the website for the current ongoing game jam
<img width="1256" alt="image" src="https://github.com/hackclub/sprig/assets/36627266/c00eaf00-22d8-497f-822f-ad07c8dd7052">
