### PR TITLE
run gdb client in docker instead of host

### DIFF
--- a/firmware/spade/docker/dockerfile
+++ b/firmware/spade/docker/dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19
 
-RUN apk add git python3 clang make cmake entr uglify-js gcc-arm-none-eabi g++-arm-none-eabi
+RUN apk add git python3 clang make cmake entr uglify-js gcc-arm-none-eabi g++-arm-none-eabi gdb-multiarch
 
 COPY ./importBuildRepos.sh /opt/importBuildRepos.sh
 

--- a/scripts/gardenshed/gdb-client.sh
+++ b/scripts/gardenshed/gdb-client.sh
@@ -1,10 +1,33 @@
 #!/bin/bash
-a=`uname`
-if [[ "$a" == "Linux" ]]; then
-	 /usr/bin/gdb-multiarch -ex 'target remote :3333' ./spade.elf 
+
+dependencies=("docker" "echo" "whoami" "grep")
+
+for dep in "${dependencies[@]}"; do
+    if ! command -v $dep > /dev/null; then
+        printf "%s not found, please install %s\n" "$dep" "$dep"
+        exit 1
+    fi
+done
+
+echo "Dependencies found successfully"
+
+# Ensure user in docker group if on linux
+if id -nG $(whoami) | grep -qw "docker"; then
+    echo User in docker group, continuing
 else
-	 /opt/homebrew/bin/arm-none-eabi-gdb -ex 'target remote :3333' ./spade.elf 
+    if [[ $OSTYPE != *"linux"* ]]; then
+        echo "Platform is not linux, skipping docker group check"
+    else
+        echo User $(whoami) not in the docker group. Please add user $(whoami) to the docker group and try again
+        exit 1
+    fi
 fi
 
+IP=$(docker network inspect bridge -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}')
 
-
+case $1 in
+    "--log") docker build ./docker | tee dockerBuildLog.txt
+             docker run -it --security-opt label:disable --rm --volume `pwd`:/root/spade $(docker images | awk '{print $3}' | awk 'NR==2') /usr/bin/gdb-multiarch -ex "target remote $IP:3333" /root/spade/spade.elf | tee -a dockerBuildLog.txt ;;
+    *) docker build ./docker
+       docker run -it --security-opt label:disable --rm --volume `pwd`:/root/spade $(docker images | awk '{print $3}' | awk 'NR==2') /usr/bin/gdb-multiarch -ex "target remote $IP:3333" /root/spade/spade.elf ;;
+esac

--- a/scripts/gardenshed/gdb-client.sh
+++ b/scripts/gardenshed/gdb-client.sh
@@ -23,11 +23,9 @@ else
     fi
 fi
 
-IP=$(docker network inspect bridge -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}')
-
 case $1 in
     "--log") docker build ./docker | tee dockerBuildLog.txt
-             docker run -it --security-opt label:disable --rm --volume `pwd`:/root/spade $(docker images | awk '{print $3}' | awk 'NR==2') /usr/bin/gdb-multiarch -ex "target remote $IP:3333" /root/spade/spade.elf | tee -a dockerBuildLog.txt ;;
+             docker run -it --security-opt label:disable --network host --rm --volume `pwd`:/root/spade $(docker images | awk '{print $3}' | awk 'NR==2') /usr/bin/gdb-multiarch -ex "target remote :3333" /root/spade/spade.elf | tee -a dockerBuildLog.txt ;;
     *) docker build ./docker
-       docker run -it --security-opt label:disable --rm --volume `pwd`:/root/spade $(docker images | awk '{print $3}' | awk 'NR==2') /usr/bin/gdb-multiarch -ex "target remote $IP:3333" /root/spade/spade.elf ;;
+       docker run -it --security-opt label:disable --network host --rm --volume `pwd`:/root/spade $(docker images | awk '{print $3}' | awk 'NR==2') /usr/bin/gdb-multiarch -ex "target remote :3333" /root/spade/spade.elf ;;
 esac

--- a/scripts/gardenshed/gdb-server.sh
+++ b/scripts/gardenshed/gdb-server.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "bindto 0.0.0.0" -c "program ./spade.elf verify reset"
+sudo openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "program ./spade.elf verify reset"

--- a/scripts/gardenshed/gdb-server.sh
+++ b/scripts/gardenshed/gdb-server.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "program ./spade.elf verify reset"
+sudo openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "bindto 0.0.0.0" -c "program ./spade.elf verify reset"


### PR DESCRIPTION
this gives gdb access to the full source tree for debugging, allowing you to view code as it's being run in GDB