### PR TITLE
properly end session after the page is onloaded or the page is closed

### DIFF
--- a/src/components/popups-etc/chat-component.tsx
+++ b/src/components/popups-etc/chat-component.tsx
@@ -7,7 +7,7 @@ import { Signal, useSignal } from "@preact/signals";
 import { RiChatDeleteLine } from "react-icons/ri";
 import markdown from "@wcj/markdown-to-html";
 import { nanoid } from "nanoid";
-import { useState } from "preact/hooks";
+import { useState, useEffect } from "preact/hooks";
 import { sha256Hash } from "../../lib/codemirror/util";
 
 interface ChatProps {
@@ -124,6 +124,27 @@ Answer the questions that follow based on this unless new code is provided.`;
 			info.value = (err as Error).message;
 		}
 	};
+
+	async function endSession() {
+		const response = await fetch(`${import.meta.env.PUBLIC_SPRIG_LLM_API}/end-session`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				session_id: chatSession
+			})
+		});
+		const result = await response.json();
+
+		if (!result.success) throw new Error("Failed to end session");
+	}
+
+	useEffect(() => {
+		window.addEventListener("beforeunload", async () => {
+			await endSession();
+		});
+	}, []);
 
 	return (
 		<div class={styles.chatUI}>


### PR DESCRIPTION
Previously after closing the sprig editor window llm chat sessions were not properly ended. 
With these changes, a request will be sent to the server to end that chat session once the window is about to be unloaded