### PR TITLE
exclude firmware, hardware and design files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
 		},
 		"importsNotUsedAsValues": "remove"
 	},
-	"exclude": [ "node_modules" ]
+	"exclude": [ "node_modules", "sprig-hax", "hardware", "firmware" ]
 }


### PR DESCRIPTION
when we run `yarn tsc --noEmit`, the typescript compiler spits multiple errors unrelated to the sprig website/editor itself.
this change tells typescript to ignore the files causing those errors which include hardware,firmware and sprig-hax folders