### PR TITLE
Add basic syntax highlighting for code responses from Sprig AI

### DIFF
--- a/src/components/popups-etc/chat-component.tsx
+++ b/src/components/popups-etc/chat-component.tsx
@@ -2,6 +2,7 @@ import useLocalStorage from "../../lib/hooks/use-local-storage";
 import { codeMirror, errorLog, PersistenceState } from "../../lib/state";
 import Button from "../design-system/button";
 import styles from "./chat-component.module.css";
+import "./chat-syntax.css";
 import { Signal, useSignal } from "@preact/signals";
 import { RiChatDeleteLine } from "react-icons/ri";
 import markdown from "@wcj/markdown-to-html";

--- a/src/components/popups-etc/chat-syntax.css
+++ b/src/components/popups-etc/chat-syntax.css
@@ -1,0 +1,30 @@
+/*
+    Pulled from CodeMirror's default syntax highlighting theme:
+
+    https://github.com/codemirror/language/blob/3c9ad8ffee32e158512d252fee9457a0e6469e2e/src/highlight.ts#L199
+*/
+
+.code-highlight .token.string {
+	color: #a11;
+}
+
+.code-highlight .token.keyword {
+	color: #708;
+}
+
+.code-highlight .token.number {
+	color: #164;
+}
+
+.code-highlight .token.comment {
+	color: #940;
+}
+
+.code-highlight .token.constant,
+.code-highlight .token.function {
+	color: #00f;
+}
+
+.code-highlight .token.class-name {
+	color: #167;
+}


### PR DESCRIPTION
everybody loves syntax highlighting!

The markdown renderer used here already handles tokenization, so this PR just adds a stylesheet to style tokens based on the editor's default light theme.

<img width="383" alt="Screenshot 2024-05-30 at 11 14 51 AM" src="https://github.com/hackclub/sprig/assets/34525547/1f29edb2-782a-460b-aefb-6c2f026cf0dd">

There are a few quirks/differences caused by how the markdown renderer works (e.g. function definitions and function calls aren't differentiated, constant declarations are styled while variable declarations aren't), but I think this is better than not having syntax highlighting at all.