### PR TITLE
store a copy of gallery images to avoid re-fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ yarn-error.log
 .env
 dist/
 games/metadata.json
+public/*.json

--- a/src/integrations/generate-metadata.ts
+++ b/src/integrations/generate-metadata.ts
@@ -9,6 +9,7 @@
  */
 import type { AstroIntegration } from "astro";
 import fs from "fs";
+import { generateImageJson } from "./thumbnail";
 
 /**
  * An object containing all of the regex expressions that can be used
@@ -74,6 +75,9 @@ const setup = () => {
 					tags: JSON.parse(tags[1].replaceAll("'", '"')), // Replace all ' with " in order for compatibility issues
 					addedOn: addedOn[1],
 				};
+
+				// generate game image json data
+				generateImageJson(metaEntry.filename);
 
 				metadata.push(metaEntry);
 				console.log(" OK!");

--- a/src/integrations/thumbnail.ts
+++ b/src/integrations/thumbnail.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import { dirname } from 'path'
 import { fileURLToPath } from 'url'
+import metrics from '../../metrics'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename);
@@ -134,7 +135,11 @@ export const generateImageJson = async (name: string) => {
 
 	// write/overwrite image json to public folder
 	let imgFilePath = path.resolve(__dirname, `../../public/${name}.json`);
-	fs.writeFileSync(imgFilePath, JSON.stringify(thumbnail), { encoding: "utf-8" });
+	fs.writeFile(imgFilePath, JSON.stringify(thumbnail), (err) => {
+		if (err) {
+			metrics.increment("errors.thumbnail_json");
+		}
+	});
 }
 
 function loadImageBase64FromDisk(name: string) {

--- a/src/integrations/thumbnail.ts
+++ b/src/integrations/thumbnail.ts
@@ -1,6 +1,5 @@
-import type { APIRoute } from 'astro'
 import { baseEngine, palette } from 'sprig/base'
-import { RawThumbnail, Thumbnail } from '../../lib/thumbnail'
+import { RawThumbnail, Thumbnail } from '../lib/thumbnail'
 import fs from 'fs'
 import path from 'path'
 import { dirname } from 'path'
@@ -102,8 +101,7 @@ const drawGameImage = (src: string): RawThumbnail => {
 	}
 }
 
-export const get: APIRoute = async ({ url }) => {
-	const name = url.searchParams.get('key') || ''
+export const generateImageJson = async (name: string) => {
 	let gameContentString = loadGameContentFromDisk(name)
 	let gameImageBase64 = loadImageBase64FromDisk(name)
 	
@@ -126,7 +124,7 @@ export const get: APIRoute = async ({ url }) => {
 		}	
 	} catch (error) {
 		// If everything breaks, use a default image
-		console.error(error)
+		// console.error(error)
 		const image = await fetch('https://cloud-i203j2e6a-hack-club-bot.vercel.app/1confused_dinosaur.png')
 		thumbnail = {
 			kind: 'png',
@@ -134,20 +132,14 @@ export const get: APIRoute = async ({ url }) => {
 		}
 	}
 
-	return new Response(JSON.stringify(thumbnail), {
-		status: 200,
-		headers: {
-			'Access-Control-Allow-Credentials': 'true',
-			'Access-Control-Allow-Origin': '*',
-			'Access-Control-Allow-Methods': 'GET,OPTIONS',
-			'Access-Control-Allow-Headers': '*',
-			'Cache-Control': 'max-age=86400'
-		}
-	})
+	// write/overwrite image json to public folder
+	let imgFilePath = path.resolve(__dirname, `../../public/${name}.json`);
+	fs.writeFileSync(imgFilePath, JSON.stringify(thumbnail), { encoding: "utf-8" });
 }
+
 function loadImageBase64FromDisk(name: string) {
 	try {
-		let imgPath = path.resolve(__dirname, `../../../games/img/${name}.png`)
+		let imgPath = path.resolve(__dirname, `../../games/img/${name}.png`)
 		if (!fs.existsSync(imgPath)) return null
 		return fs.readFileSync(imgPath).toString("base64")
 	} catch {
@@ -156,8 +148,7 @@ function loadImageBase64FromDisk(name: string) {
 }
 
 function loadGameContentFromDisk(name: string) {	
-	let gameContentPath = path.resolve(__dirname, `../../../games/${name}.js`)
+	let gameContentPath = path.resolve(__dirname, `../../games/${name}.js`)
 	if (!fs.existsSync(gameContentPath)) return null
 	return fs.readFileSync(gameContentPath).toString()
 }
-

--- a/src/lib/thumbnail.ts
+++ b/src/lib/thumbnail.ts
@@ -25,7 +25,7 @@ const decode = ({ data, width }: RawThumbnail) => {
 }
 
 export const loadThumbnailUrl = async (key: string): Promise<string> => {
-	const res = await fetch(`/api/thumbnail?key=${encodeURIComponent(key)}`)
+	const res = await fetch(`/${key}.json`)
 	const json = await res.json() as Thumbnail
 
 	if (json.kind === 'png') {

--- a/src/pages/gallery/gallery.tsx
+++ b/src/pages/gallery/gallery.tsx
@@ -3,7 +3,6 @@ import { loadThumbnailUrl } from "../../lib/thumbnail";
 import { GameMetadata } from "../../lib/game-saving/gallery";
 import Button from "../../components/design-system/button";
 import Input from "../../components/design-system/input";
-import { signal } from "@preact/signals";
 import { IoCaretDown, IoSearch } from "react-icons/io5";
 import "./gallery.css";
 
@@ -14,14 +13,11 @@ enum SortOrder {
 	DESCENDING
 }
 type GalleryGameMetadata = GameMetadata & { show: boolean };
-type GameImageUri = string;
-type GameImages =  Record<string, GameImageUri>;
 type Filter = {
 	query: string,
 	tags: string[],
 	sort: SortOrder
-};
-const gameImages = signal<GameImages>({});
+}
 
 export default function Gallery({ games, tags }: { games: GameMetadata[], tags: string[] }) {
 	const [gamesState, setGamesState] = useState<GalleryGameMetadata[]>([]);
@@ -116,15 +112,8 @@ export default function Gallery({ games, tags }: { games: GameMetadata[], tags: 
 			) as HTMLImageElement;
 			if (["loading", "true"].includes(img.dataset.loaded!)) return;
 			img.dataset.loaded = "loading";
-			if (gameImages.value[gameCard.filename]) {
-				img.src = gameImages.value[gameCard.filename]!;
-			} else {
-				const thumbnail = await loadThumbnailUrl(gameCard.filename);
-				img.src = thumbnail;
-				const newGameImages = { ...gameImages.value };
-				newGameImages[gameCard.filename] = thumbnail;
-				gameImages.value = newGameImages;
-			}
+			const thumbnail = await loadThumbnailUrl(gameCard.filename);
+			img.src = thumbnail;
 			img.dataset.loaded = "true";
 		};
 

--- a/src/pages/gallery/gallery.tsx
+++ b/src/pages/gallery/gallery.tsx
@@ -3,6 +3,7 @@ import { loadThumbnailUrl } from "../../lib/thumbnail";
 import { GameMetadata } from "../../lib/game-saving/gallery";
 import Button from "../../components/design-system/button";
 import Input from "../../components/design-system/input";
+import { signal } from "@preact/signals";
 import { IoCaretDown, IoSearch } from "react-icons/io5";
 import "./gallery.css";
 
@@ -20,9 +21,10 @@ type Filter = {
 	tags: string[],
 	sort: SortOrder
 };
+const gameImages = signal<GameImages>({});
+
 export default function Gallery({ games, tags }: { games: GameMetadata[], tags: string[] }) {
 	const [gamesState, setGamesState] = useState<GalleryGameMetadata[]>([]);
-	const [gameImages, setGameImages] = useState<GameImages>({});
 	const [filter, setFilter] = useState<Filter>({ query: "", sort: SortOrder.TUTORIALS_AND_CHRONOLOGICAL, tags: [] })
 	const [tagCount, setTagCount] = useState<{ [tags: string]: number }>({})
 
@@ -114,17 +116,14 @@ export default function Gallery({ games, tags }: { games: GameMetadata[], tags: 
 			) as HTMLImageElement;
 			if (["loading", "true"].includes(img.dataset.loaded!)) return;
 			img.dataset.loaded = "loading";
-			if (gameImages[gameCard.filename]) {
-				img.src = gameImages[gameCard.filename]!;
+			if (gameImages.value[gameCard.filename]) {
+				img.src = gameImages.value[gameCard.filename]!;
 			} else {
 				const thumbnail = await loadThumbnailUrl(gameCard.filename);
 				img.src = thumbnail;
-				setGameImages(previousImages => {
-					const newGameImages = { ...previousImages };
-					newGameImages[gameCard.filename] = thumbnail;
-					return newGameImages;
-				}
-				);
+				const newGameImages = { ...gameImages.value };
+				newGameImages[gameCard.filename] = thumbnail;
+				gameImages.value = newGameImages;
 			}
 			img.dataset.loaded = "true";
 		};

--- a/src/pages/gallery/gallery.tsx
+++ b/src/pages/gallery/gallery.tsx
@@ -13,6 +13,8 @@ enum SortOrder {
 	DESCENDING
 }
 type GalleryGameMetadata = GameMetadata & { show: boolean };
+type GameImageUri = string;
+type GameImages =  Record<string, GameImageUri>;
 type Filter = {
 	query: string,
 	tags: string[],
@@ -20,6 +22,7 @@ type Filter = {
 };
 export default function Gallery({ games, tags }: { games: GameMetadata[], tags: string[] }) {
 	const [gamesState, setGamesState] = useState<GalleryGameMetadata[]>([]);
+	const [gameImages, setGameImages] = useState<GameImages>({});
 	const [filter, setFilter] = useState<Filter>({ query: "", sort: SortOrder.TUTORIALS_AND_CHRONOLOGICAL, tags: [] })
 	const [tagCount, setTagCount] = useState<{ [tags: string]: number }>({})
 
@@ -111,7 +114,18 @@ export default function Gallery({ games, tags }: { games: GameMetadata[], tags: 
 			) as HTMLImageElement;
 			if (["loading", "true"].includes(img.dataset.loaded!)) return;
 			img.dataset.loaded = "loading";
-			img.src = await loadThumbnailUrl(gameCard.filename);
+			if (gameImages[gameCard.filename]) {
+				img.src = gameImages[gameCard.filename]!;
+			} else {
+				const thumbnail = await loadThumbnailUrl(gameCard.filename);
+				img.src = thumbnail;
+				setGameImages(previousImages => {
+					const newGameImages = { ...previousImages };
+					newGameImages[gameCard.filename] = thumbnail;
+					return newGameImages;
+				}
+				);
+			}
 			img.dataset.loaded = "true";
 		};
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+	"headers": [
+		{
+			"source": "/(.*)",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=1800"
+				}
+			]
+		}
+	]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
 	"headers": [
 		{
-			"source": "/(.*)",
+			"source": "/(.*\\.json)",
 			"headers": [
 				{
 					"key": "Cache-Control",


### PR DESCRIPTION
#1396 

Right now, every time you perform a search the game thumbnail is re-fetched from the server. 

Now game image data is generated at build time and stored in the public folder. These image data are cached through vercel resulting in less resources transferred.