### PR TITLE
keep game files in production build

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,9 @@ import vercel from '@astrojs/vercel/serverless'
 import prefresh from '@prefresh/vite'
 import svelte from '@astrojs/svelte'
 import rehypeExternalLinks from 'rehype-external-links'
+import fs from "node:fs";
 
+const gameFiles = fs.readdirSync("games").filter(f => f.endsWith(".js")).map(game => `./games/${game}`);
 import generateMetadata from "./src/integrations/generate-metadata"
 
 export default defineConfig({
@@ -15,7 +17,9 @@ export default defineConfig({
 		generateMetadata()
 	],
 	output: 'server',
-	adapter: vercel(),
+	adapter: vercel({
+		includeFiles: gameFiles,
+	}),
 	vite: {
 		optimizeDeps: {
 			exclude: ['https']

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,9 +5,9 @@ import prefresh from '@prefresh/vite'
 import svelte from '@astrojs/svelte'
 import rehypeExternalLinks from 'rehype-external-links'
 import fs from "node:fs";
+import generateMetadata from "./src/integrations/generate-metadata"
 
 const gameFiles = fs.readdirSync("games").filter(f => f.endsWith(".js")).map(game => `./games/${game}`);
-import generateMetadata from "./src/integrations/generate-metadata"
 
 export default defineConfig({
 	site: 'https://sprig.hackclub.com',


### PR DESCRIPTION
because the thumbnail api function was removed and the game preview json files was only generated at build time, astro will optimize and remove the games since they were only read at build time as compared to every time a request was made when using the thumbnail api function