### PR TITLE
Add http prefix to web requests

### DIFF
--- a/src/integrations/thumbnail.ts
+++ b/src/integrations/thumbnail.ts
@@ -137,7 +137,7 @@ export const generateImageJson = async (name: string) => {
 	let imgFilePath = path.resolve(__dirname, `../../public/${name}.json`);
 	fs.writeFile(imgFilePath, JSON.stringify(thumbnail), (err) => {
 		if (err) {
-			metrics.increment("errors.thumbnail_json");
+			metrics.increment("http.errors.thumbnail_json");
 		}
 	});
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,7 @@ export async function onRequest({ request }: any, next: () => any) {
   const response = await next();
   const time = performance.now() - start;
 
-  const metricKey = `${response.status}.${metricName}`;
+  const metricKey = `http.${response.status}.${metricName}`;
   console.log(metricKey);
   metrics.increment(metricKey, 1);
   metrics.timing(metricName, time);


### PR DESCRIPTION
Because we want tot differentiate between db, http, and signaling server (in the future) metrics