### PR TITLE
fixing line numbers in sprig editor error handling

### DIFF
--- a/src/lib/engine/error.ts
+++ b/src/lib/engine/error.ts
@@ -146,7 +146,7 @@ export const normalizeGameError = (gameError: GameError): NormalizedError => {
  * Finds the line and column of innermost error from a stack.
  * This is modified code from V1.
  */
-function findErrorLineCol(stack: string | undefined): [number | null, number | null] {
+function findErrorLineCol(stack: string | undefined, lineOffset: number): [number | null, number | null] {
 	if (!stack) return [null, null]
 
 	let line = null
@@ -157,7 +157,7 @@ function findErrorLineCol(stack: string | undefined): [number | null, number | n
 
 	if (location) {
 		let lineCol = location[1]!.split(":").map(Number)
-		line = lineCol[0]! - 2
+		line = lineCol[0]! - lineOffset
 		col = lineCol[1]!
 	}
 

--- a/src/lib/engine/index.ts
+++ b/src/lib/engine/index.ts
@@ -75,7 +75,7 @@ export function runGame(code: string, canvas: HTMLCanvasElement, onPageError: (e
 		fn(...Object.values(api))
 		return { error: null, cleanup }
 	} catch (error: any) {
-		// if there's an error code, it's most likely a babel error of some kind 
+		// if there's an error code, it's most likely a babel error of some kind
 		// other errors do not have an error code attached
 		if (!error.code) {
 			const normalizedError = normalizeGameError({ kind: "runtime", error });
@@ -83,8 +83,10 @@ export function runGame(code: string, canvas: HTMLCanvasElement, onPageError: (e
 		} 
 
 		// At least for SyntaxErrors, the type of error shows as "unknown" instead of "SyntaxError" - this replaces that
-		if (error.message.split(":")[0] == 'unknown') {
-			error.message = error.message.replace('unknown', error.name)
+		if (error.message) {
+			if (error.message.split(":")[0] == 'unknown') {
+				error.message = error.message.replace('unknown', error.name)
+			}
 		}
 
 		return {

--- a/src/lib/engine/index.ts
+++ b/src/lib/engine/index.ts
@@ -79,9 +79,14 @@ export function runGame(code: string, canvas: HTMLCanvasElement, onPageError: (e
 		// other errors do not have an error code attached
 		if (!error.code) {
 			const normalizedError = normalizeGameError({ kind: "runtime", error });
-			normalizedError!.line! += 1;
 			return { error: normalizedError, cleanup };
 		} 
+
+		// At least for SyntaxErrors, the type of error shows as "unknown" instead of "SyntaxError" - this replaces that
+		if (error.message.split(":")[0] == 'unknown') {
+			error.message = error.message.replace('unknown', error.name)
+		}
+
 		return {
 			error: {
 				raw: error,


### PR DESCRIPTION
I shifted the line numbers so they align with the actual errors and added line numbers to infinite recursion and URI errors.