### PR TITLE
Feat: Run button with Run and dropdown

### DIFF
--- a/src/components/big-interactive-pages/editor.tsx
+++ b/src/components/big-interactive-pages/editor.tsx
@@ -1,38 +1,35 @@
-import styles from "./editor.module.css";
-import CodeMirror from "../codemirror";
-import Navbar from "../navbar-editor";
-import {
-	IoClose,
-	IoPlayCircleOutline,
-	IoStopCircleOutline,
-	IoVolumeHighOutline,
-	IoVolumeMuteOutline,
-} from "react-icons/io5";
 import {
 	Signal,
 	useComputed,
 	useSignal,
 	useSignalEffect,
 } from "@preact/signals";
-import { useEffect, useRef, useState} from "preact/hooks";
-import { codeMirror, errorLog, isNewSaveStrat, muted, PersistenceState, RoomState } from "../../lib/state";
-import EditorModal from "../popups-etc/editor-modal";
-import { runGame } from "../../lib/engine";
-import DraftWarningModal from "../popups-etc/draft-warning";
-import Button from "../design-system/button";
-import { debounce } from "throttle-debounce";
-import Help from "../popups-etc/help";
-import { collapseRanges } from "../../lib/codemirror/util";
-import { defaultExampleCode } from "../../lib/examples";
-import MigrateToast from "../popups-etc/migrate-toast";
 import { nanoid } from "nanoid";
-import TutorialWarningModal from "../popups-etc/tutorial-warning";
-import { editSessionLength, switchTheme, ThemeType, continueSaving, LAST_SAVED_SESSION_ID, showSaveConflictModal } from '../../lib/state'
-import SessionConflictWarningModal from '../popups-etc/session-conflict-warning-modal'
-import {versionState} from "../../lib/upload";
-import VersionWarningModal from "../popups-etc/version-warning";
+import { useEffect, useRef, useState } from "preact/hooks";
+import {
+	IoClose,
+	IoStopCircleOutline,
+	IoVolumeHighOutline,
+	IoVolumeMuteOutline,
+} from "react-icons/io5";
+import { debounce } from "throttle-debounce";
+import { collapseRanges } from "../../lib/codemirror/util";
+import { runGame } from "../../lib/engine";
+import { defaultExampleCode } from "../../lib/examples";
+import { codeMirror, continueSaving, editSessionLength, errorLog, isNewSaveStrat, LAST_SAVED_SESSION_ID, muted, PersistenceState, RoomState, showSaveConflictModal, switchTheme, ThemeType } from "../../lib/state";
+import { versionState } from "../../lib/upload";
+import CodeMirror from "../codemirror";
+import Navbar from "../navbar-editor";
+import DraftWarningModal from "../popups-etc/draft-warning";
+import EditorModal from "../popups-etc/editor-modal";
+import Help from "../popups-etc/help";
+import KeyBindingsModal from '../popups-etc/KeyBindingsModal';
+import MigrateToast from "../popups-etc/migrate-toast";
 import RoomPasswordPopup from "../popups-etc/room-password";
-import KeyBindingsModal from '../popups-etc/KeyBindingsModal'
+import SessionConflictWarningModal from '../popups-etc/session-conflict-warning-modal';
+import TutorialWarningModal from "../popups-etc/tutorial-warning";
+import VersionWarningModal from "../popups-etc/version-warning";
+import styles from "./editor.module.css";
 
 let screenRef: HTMLCanvasElement | null = null;
 let cleanupRef: (() => void) | undefined = undefined;

--- a/src/components/design-system/button.tsx
+++ b/src/components/design-system/button.tsx
@@ -1,20 +1,20 @@
-import type { ComponentChild, JSX } from 'preact'
-import type { IconType } from 'react-icons'
-import styles from './button.module.css'
+import type { ComponentChild, JSX } from "preact";
+import type { IconType } from "react-icons";
+import styles from "./button.module.css";
 
 interface ButtonProps {
-	icon?: IconType
-	type?: 'button' | 'submit' | 'reset'
-	iconSide?: 'left' | 'right'
-	bigIcon?: boolean
-	accent?: boolean
-	class?: string | undefined
-	disabled?: boolean
-	spinnyIcon?: boolean
-	loading?: boolean
-	children?: ComponentChild
-	role?: JSX.HTMLAttributes<HTMLButtonElement>['role']
-	onClick?: () => void
+	icon?: IconType;
+	type?: "button" | "submit" | "reset";
+	iconSide?: "left" | "right";
+	bigIcon?: boolean;
+	accent?: boolean;
+	class?: string | undefined;
+	disabled?: boolean;
+	spinnyIcon?: boolean;
+	loading?: boolean;
+	children?: ComponentChild;
+	role?: JSX.HTMLAttributes<HTMLButtonElement>["role"];
+	onClick?: (e: JSX.TargetedMouseEvent<HTMLButtonElement>) => void;
 }
 
 export default function Button(props: ButtonProps) {
@@ -22,20 +22,20 @@ export default function Button(props: ButtonProps) {
 		<button
 			class={`
 				${styles.button}
-				${props.accent ? styles.accent : ''}
-				${props.bigIcon ? styles.bigIcon : ''}
-				${props.spinnyIcon ? styles.spinnyIcon : ''}
-				${props.loading ? styles.loading : ''}
-				${props.class ?? ''}
+				${props.accent ? styles.accent : ""}
+				${props.bigIcon ? styles.bigIcon : ""}
+				${props.spinnyIcon ? styles.spinnyIcon : ""}
+				${props.loading ? styles.loading : ""}
+				${props.class ?? ""}
 			`}
-			role={props.role ?? 'button'}
-			type={props.type ?? 'button'}
+			role={props.role ?? "button"}
+			type={props.type ?? "button"}
 			disabled={!!props.disabled || !!props.loading}
-			onClick={() => props.onClick?.()}
+			onClick={(e) => props.onClick?.(e)}
 		>
-			{props.icon && props.iconSide !== 'right' && <props.icon />}
+			{props.icon && props.iconSide !== "right" && <props.icon />}
 			{props.children}
-			{props.icon && props.iconSide === 'right' && <props.icon />}
+			{props.icon && props.iconSide === "right" && <props.icon />}
 		</button>
-	)
+	);
 }

--- a/src/components/navbar-editor.tsx
+++ b/src/components/navbar-editor.tsx
@@ -393,11 +393,31 @@ export default function EditorNavbar(props: EditorNavbarProps) {
 									  );
 							}}
 						>
-							{runMode.value == "run" ? "Run" : "Run on Device"}
 							<span
-								onClick={() =>
-									(showDropdown.value = !showDropdown.value)
-								}
+								style={{
+									marginRight: "-0.25rem",
+									marginLeft: "-0.25rem",
+								}}
+							>
+								{runMode.value == "run"
+									? "Run"
+									: "Run on Device"}
+							</span>
+						</Button>
+						<Button
+							accent
+							onClick={() =>
+								(showDropdown.value = !showDropdown.value)
+							}
+						>
+							<span
+								style={{
+									height: "17.281px",
+									marginLeft: "-0.5rem",
+									marginRight: "-0.5rem",
+									display: "flex",
+									alignItems: "center",
+								}}
 							>
 								<IoChevronDown />
 							</span>


### PR DESCRIPTION
Hard to explain. #2063 replaced the `Run` button in the editor with a dropdown where the old `Run on Device` button used to be. This groups the very similar actioned buttons but makes the action of running the game from 1 to 2 clicks (**gasps**). However, it might not seem like much it's annoying and may add up in time. This is why I made the button do the most recent action, and the chevron activates the dropdown. I'm not familiar with Astro and it's been a while since I used React so the code shouldn't be shippable but was merely made to show what I mean.

![image](https://github.com/user-attachments/assets/3ce1a7e6-288d-4f3c-9374-855bbfc2d8ea)
![image](https://github.com/user-attachments/assets/ea44974b-cb51-4a7d-a206-80cfcb3cfa9c)
Main Run button runs the game

#1971 