### PR TITLE
cast environment variables to valid numbers for comparison/usage

### DIFF
--- a/src/components/big-interactive-pages/login.tsx
+++ b/src/components/big-interactive-pages/login.tsx
@@ -57,7 +57,7 @@ export default function Login({ session, email, to }: LoginProps) {
 						</p>
 						<Input onChange={() => undefined} value={auth.code.value} id='code' type='text' maxLength={auth.email.value == DevEmail ? 70 : 6} placeholder='123456'  bind={auth.code} />
 						{auth.state.value === 'CODE_INCORRECT' && <p class={styles.error}>Incorrect login code.</p>}
-						{auth.state.value === 'ACCOUNT_LOCKED' && <p class={styles.error}>Account locked due to too many failed attempts. Please try again later.</p>}
+						{auth.state.value === 'ACCOUNT_LOCKED' && <p class={styles.error}>Account locked due to too many failed attempts. Please try again in {+import.meta.env.PUBLIC_LOCKOUT_DURATION_MS / 60000} minutes.</p>}
 
                         <Button class={styles.submit} accent type='submit' disabled={!auth.codeValid.value || auth.state.value === 'ACCOUNT_LOCKED'} loading={auth.isLoading.value}>
 							Finish logging in

--- a/src/pages/api/auth/submit-code.ts
+++ b/src/pages/api/auth/submit-code.ts
@@ -55,9 +55,9 @@ export const post: APIRoute = async ({ request, cookies }) => {
     if (_codes.empty) {
 		const newFailedAttempts = failedLoginAttempts + 1;
 
-		if (newFailedAttempts >= import.meta.env.MAX_ATTEMPTS) {
+		if (newFailedAttempts >= +import.meta.env.MAX_ATTEMPTS) {
 			const lockoutUntil = Timestamp.fromMillis(
-				now.toMillis() + import.meta.env.LOCKOUT_DURATION_MS
+				now.toMillis() + parseInt(import.meta.env.LOCKOUT_DURATION_MS)
 			);
 			await updateDocument("users", user.id, {
 				failedLoginAttempts: newFailedAttempts,

--- a/src/pages/api/auth/submit-code.ts
+++ b/src/pages/api/auth/submit-code.ts
@@ -57,7 +57,7 @@ export const post: APIRoute = async ({ request, cookies }) => {
 
 		if (newFailedAttempts >= +import.meta.env.MAX_ATTEMPTS) {
 			const lockoutUntil = Timestamp.fromMillis(
-				now.toMillis() + parseInt(import.meta.env.LOCKOUT_DURATION_MS)
+				now.toMillis() + parseInt(import.meta.env.PUBLIC_LOCKOUT_DURATION_MS)
 			);
 			await updateDocument("users", user.id, {
 				failedLoginAttempts: newFailedAttempts,


### PR DESCRIPTION
Previously, the Sprig editor will fail to correctly set the lockoutUntil in firebase because the lockout duration was not taken as a valid number.