### PR TITLE
fix Navbar color on /get is inconsistent

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -33,9 +33,9 @@ body {
 	--fg-muted: #9d9d9d;
 	--fg-muted-on-accent: #8fcabb;
 	--error: #e03131;
-	--accent: #399F6E;
+	--accent: #078969;
 	--accent-light: #80c3a0;
-	--accent-dark: #0B6F3B; /* #136853; */
+	--accent-dark: #136853;
 	--fg-switch-low: #515151;
 	--fg-switch-high: #f3f3f3;
 


### PR DESCRIPTION
there's other ways to fix:
changing legacy css files;
changing /get css to a style tag inside it;
making /get own css file;
.....
why this solution?
fixes other color inconsistents

fixes #2259 