### PR TITLE
fix tune editor going of sync and throwing `Out-of-order effect` error

### DIFF
--- a/src/components/codemirror-widgets/open-button.tsx
+++ b/src/components/codemirror-widgets/open-button.tsx
@@ -14,7 +14,7 @@ export default function OpenButton(props: OpenButtonProps) {
 	return (
 		<button
 			class={styles.openButton}
-			onClick={async (event) => {
+			onClick={async () => {
 				if (!codeMirror.value) return
 
 

--- a/src/components/popups-etc/editor-modal.tsx
+++ b/src/components/popups-etc/editor-modal.tsx
@@ -87,7 +87,7 @@ export default function EditorModal() {
 		if (!openEditor.value) return;
 
 		const code = codeMirror.value?.state.doc.toString() ?? '';
-		const levenshtainDistances = _foldRanges.value.map((foldRange, foldRangeIndex) => {
+		const levenshteinDistances = _foldRanges.value.map((foldRange, foldRangeIndex) => {
 			const widgetKind = _widgets.value[foldRangeIndex]?.value.spec.widget.props.kind;
 
 			// if the widget kind is not the same as the open editor kind, don't do anything
@@ -100,13 +100,13 @@ export default function EditorModal() {
 		});
 
 		// if (levenshtainDistances.length === 0) alert(`You are currently editing a deleted ${openEditor.value?.kind}`);
-		if (levenshtainDistances.length === 0) return;
+		if (levenshteinDistances.length === 0) return;
 
 		// compute the index of the min distance
 		let indexOfMinDistance = 0;
-		levenshtainDistances.forEach((distance, didx) => {
-			if (levenshtainDistances[indexOfMinDistance]! < 0) indexOfMinDistance = didx;
-			const min = levenshtainDistances[indexOfMinDistance]!;
+		levenshteinDistances.forEach((distance, didx) => {
+			if (levenshteinDistances[indexOfMinDistance]! < 0) indexOfMinDistance = didx;
+			const min = levenshteinDistances[indexOfMinDistance]!;
 			if (distance >= 0 && distance <= min) indexOfMinDistance = didx;
 		});
 

--- a/src/components/popups-etc/editor-modal.tsx
+++ b/src/components/popups-etc/editor-modal.tsx
@@ -22,8 +22,21 @@ export default function EditorModal() {
 		if (openEditor.value) text.value = openEditor.value.text
 	})
 
+	/**
+	 * @Josias
+	 * The two useEffect's below can be naughty but they help ensure two things
+	 * 1. If an update comes from the underlying codemirror document, the first effect doesn't run as we're already updating the editor modal from there
+	 * 2. If an update was originally made from the currently open editor modal, the changes to the codemirror document will
+	 * not trigger an update to the open editor modal
+	 * 
+	 * Both of these help us avoid Out-of-order errors or Cycles
+	 */
+
 	// Sync editor text changes with code
-	useEffect(() => {
+	useEffect(() => { // useEffect #1
+		// if update comes from codemirror doc (probably from a collab session)
+		// this ensures that updates are not triggered from this effect which may cause an 
+		// Out-of-order / Cycles
 		if (updateCulprit === UpdateCulprit.CodeMirror) {
 			setUpdateCulprit(UpdateCulprit.RESET);
 			return;
@@ -54,6 +67,9 @@ export default function EditorModal() {
 
 
 	useEffect(() => {
+		// if update comes from codemirror doc (probably from a collab session)
+		// this ensures that updates are not triggered from this effect which may cause an 
+		// Out-of-order / Cycles
 		if (updateCulprit === UpdateCulprit.OpenEditor) {
 			setUpdateCulprit(UpdateCulprit.RESET);
 			return;

--- a/src/components/subeditors/sequencer.tsx
+++ b/src/components/subeditors/sequencer.tsx
@@ -150,13 +150,15 @@ export default function SequencerEditor(props: EditorProps) {
 	}
 
 	// Sync text changes with cells
-	useSignalEffect(() => {
-		const newCells = tuneToCells(textToTune(props.text.value))
+	useEffect(() => {
+		const newCells = tuneToCells(textToTune(props.text.value));
 		const count = props.text.value.match(/(.+):/)
 		bpm.value = count ? Math.round(60 * 1000 / Number(count[1])) : 120
 		if (!cellsEq(newCells, cells.peek())) // Perf boost for rapid BPM changes
 			cells.value = newCells
-	})
+	
+	}, [ props.text.value ]);
+
 	// Sync cell changes with text
 	useSignalEffect(() => {
 		props.text.value = '\n' + tuneToText(cellsToTune(cells.value, bpm.value)).trim()


### PR DESCRIPTION
Fixes #2312 

The two useEffect's in `editor-modal.tsx` can be naughty but they help ensure two things
1. If an update comes from the underlying codemirror document, the first effect doesn't run as we're already updating the editor modal from there
2. If an update was originally made from the currently open editor modal, the changes to the codemirror document will not trigger an update to the open editor modal 
 
Both of these help us avoid Out-of-order errors or Cycles