### PR TITLE
fold template literals after update has been propagated in editor

### DIFF
--- a/src/components/big-interactive-pages/editor.tsx
+++ b/src/components/big-interactive-pages/editor.tsx
@@ -88,6 +88,14 @@ const minHelpAreaHeight = 32;
 let defaultHelpAreaHeight = 350;
 const helpAreaHeightMargin = 0; // The margin between the screen and help area
 
+export const foldTemplateLiteral = (from: number, to: number) => {
+	if (!codeMirror.value) return;
+	collapseRanges(
+		codeMirror.value,
+		[[from, to]]
+	);
+}
+
 export const foldAllTemplateLiterals = () => {
 	if (!codeMirror.value) return;
 	const code = codeMirror.value.state.doc.toString() ?? "";

--- a/src/components/popups-etc/editor-modal.tsx
+++ b/src/components/popups-etc/editor-modal.tsx
@@ -7,7 +7,6 @@ import { codeMirror, editors, openEditor, codeMirrorEditorText, _foldRanges, _wi
 import styles from './editor-modal.module.css'
 import levenshtein from 'js-levenshtein'
 import { runGameHeadless } from '../../lib/engine'
-import { foldAllTemplateLiterals } from "../big-interactive-pages/editor"
 
 const enum LastUpdater {
 	RESET,
@@ -18,8 +17,6 @@ export default function EditorModal() {
 	const Content = openEditor.value ? editors[openEditor.value.kind].modalContent : () => null
 	const text = useSignal(openEditor.value?.text ?? '');
 	const [lastUpdater, setLastUpdater] = useState<LastUpdater>(LastUpdater.RESET);
-
-  const setUpdaterAndFold = (lastUpdater: LastUpdater) => { setLastUpdater(lastUpdater); foldAllTemplateLiterals(); }
 
 	useSignalEffect(() => {
 		if (openEditor.value) text.value = openEditor.value.text
@@ -41,7 +38,7 @@ export default function EditorModal() {
 		// this ensures that updates are not triggered from this effect which may cause an
 		// Out-of-order / Cycles
 		if (lastUpdater === LastUpdater.CodeMirror) {
-			setUpdaterAndFold(LastUpdater.RESET);
+			setLastUpdater(LastUpdater.RESET);
 			return;
 		}
 		// Signals are killing me but useEffect was broken and I need to ship this
@@ -65,7 +62,7 @@ export default function EditorModal() {
 				to: _openEditor.editRange.from + _text.length
 			}
 		}
-		setUpdaterAndFold(LastUpdater.OpenEditor);
+		setLastUpdater(LastUpdater.OpenEditor);
 	}, [text.value]);
 
 
@@ -74,12 +71,12 @@ export default function EditorModal() {
 		// this ensures that updates are not triggered from this effect which may cause an
 		// Out-of-order / Cycles
 		if (lastUpdater === LastUpdater.OpenEditor) {
-			setUpdaterAndFold(LastUpdater.RESET);
+			setLastUpdater(LastUpdater.RESET);
 			return;
 		}
 		// just do this to sync the editor text with the code mirror text
 		computeAndUpdateModalEditor();
-		setUpdaterAndFold(LastUpdater.CodeMirror);
+		setLastUpdater(LastUpdater.CodeMirror);
 		// updateCulprit.value = UPDATE_CULPRIT.CodeMirror;
 	}, [codeMirrorEditorText.value]);
 

--- a/src/lib/codemirror/init.ts
+++ b/src/lib/codemirror/init.ts
@@ -3,14 +3,15 @@ import { getSearchQuery, highlightSelectionMatches, search, searchKeymap, setSea
 import widgets from './widgets'
 import { effect, signal } from '@preact/signals'
 import { h, render } from 'preact'
-import { bracketMatching, defaultHighlightStyle, foldGutter, foldKeymap, indentOnInput, indentUnit, syntaxHighlighting } from '@codemirror/language'
+import { bracketMatching, defaultHighlightStyle, foldedRanges, foldEffect, unfoldEffect, foldGutter, foldKeymap, indentOnInput, indentUnit, syntaxHighlighting } from '@codemirror/language'
 import { history, defaultKeymap, historyKeymap, indentWithTab, insertNewlineAndIndent } from '@codemirror/commands'
 import { javascript } from '@codemirror/lang-javascript'
 import SearchBox from '../../components/search-box'
 import { EditorView, keymap, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, dropCursor, rectangularSelection, crosshairCursor, highlightActiveLine } from '@codemirror/view'
 import { lintGutter } from "@codemirror/lint";
 import type { NormalizedError } from '../state'
-import { codeMirrorEditorText } from '../state'
+import { codeMirrorEditorText, lastFoldRanges, codeMirror } from '../state'
+import { foldTemplateLiteral } from '../../components/big-interactive-pages/editor'
 
 export function diagnosticsFromErrorLog(view: EditorView, errorLog: NormalizedError[]) {
 	return errorLog.filter(error => error.line)
@@ -27,6 +28,42 @@ export function diagnosticsFromErrorLog(view: EditorView, errorLog: NormalizedEr
 
 export const initialExtensions = (onUpdate: any, onRunShortcut: any, yCollab?: any) => ([
 	EditorView.updateListener.of(update => {
+		update.transactions.forEach(transaction => {
+			// if it's a simple fold/unfold command, resolve
+			const isFoldOrUnfoldEffect = transaction.effects.map(stateEffect => {
+				return stateEffect.is(unfoldEffect) || stateEffect.is(foldEffect)
+			});
+
+			if (isFoldOrUnfoldEffect.includes(true)) return;
+
+			const previousFoldedRanges = foldedRanges(transaction.startState);
+			const currentFoldedRanges = foldedRanges(codeMirror.value!.state);
+			function arrayFromFoldRangeIter(foldRanges: any) {
+				const iter = foldRanges.iter();
+				const out: any[] = [];
+				while (iter.value != null) {
+					out.push({ from: iter.from, to: iter.to });
+					iter.next();
+				}
+				return out;
+			}
+
+			const previousFoldRanges = arrayFromFoldRangeIter(previousFoldedRanges);
+			const currentFoldRanges = arrayFromFoldRangeIter(currentFoldedRanges);
+
+			const foldRangeDiffs = [
+				...previousFoldRanges.filter(range => {
+					return !currentFoldRanges.some(oRange => (oRange.from === range.from && oRange.to === range.to))
+				}),
+				...currentFoldRanges.filter(range => {
+					return !previousFoldRanges.some(oRange => (oRange.from === range.from && oRange.to === range.to))
+				}),
+			];
+
+			foldRangeDiffs.forEach(range => foldTemplateLiteral(range.from, range.to));
+
+		});
+
 		const newEditorText = update.state.doc.toString();
 		codeMirrorEditorText.value = newEditorText;
 	}),

--- a/src/lib/codemirror/init.ts
+++ b/src/lib/codemirror/init.ts
@@ -10,7 +10,7 @@ import SearchBox from '../../components/search-box'
 import { EditorView, keymap, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, dropCursor, rectangularSelection, crosshairCursor, highlightActiveLine } from '@codemirror/view'
 import { lintGutter } from "@codemirror/lint";
 import type { NormalizedError } from '../state'
-import { codeMirrorEditorText, lastFoldRanges, codeMirror } from '../state'
+import { codeMirrorEditorText, codeMirror } from '../state'
 import { foldTemplateLiteral } from '../../components/big-interactive-pages/editor'
 
 export function diagnosticsFromErrorLog(view: EditorView, errorLog: NormalizedError[]) {


### PR DESCRIPTION
resolves #2368 

when a change is propagated to bitmaps/map/tune, their template literals get unfolded and the change applied. however, they're not closed back. this change forces the template literals to fold after these changes have been applied to the editor. 