### PR TITLE
Fix UI Not Displaying For Run On Device & Github PR

### DIFF
--- a/src/components/navbar.module.css
+++ b/src/components/navbar.module.css
@@ -11,7 +11,6 @@
 	position: relative;
 	text-align: center;
 	justify-content: space-between;
-	white-space: nowrap; /* P3baf */
 	overflow: hidden; /* Pad2a */
 }
 


### PR DESCRIPTION
On the Recent deploy , both UI for Github PR button and dropdown of Github had stop showing due the recent commit made on #2561 where the use of `white-space: nowrap; /* P3baf */` caused the issue. This PR removes that and fixes the issue

Why did it broke?

The main case of using this `white-space: nowrap; /* P3baf */` is to remain the container or items on a single line without wrapping. Our UI with multiple text , input field exceeds the container width and it got clipped causing the UI to not show up causing it to break it.

 