### PR TITLE
Fixing StickRunner Game

### DIFF
--- a/games/StickRunner.js
+++ b/games/StickRunner.js
@@ -282,7 +282,6 @@ hghghghghghghghghghghghghghghg`,
       x: 1,
       y: 5,
     })
-    }
     addText("" + score, { 
       x: 1,
       y: 5,


### PR DESCRIPTION
The game had an extra bracket that gave an error so it was unplayable. This pr removes that bracket.