### PR TITLE
Fix The Tomb of a Thousand (T)errors Game

### DIFF
--- a/games/TheTombOfAThousandTerrors.js
+++ b/games/TheTombOfAThousandTerrors.js
@@ -346,7 +346,7 @@ function startLevel() {
 
   levelState.mapSizeX = def.size[0];
   levelState.mapSizeY = def.size[1];
-  levelState.map = getGrid(levelState.mapSizeX, levelState.mapSizeY);
+  levelState.map = getGridFunction(levelState.mapSizeX, levelState.mapSizeY);
   levelState.map = generatePrimMaze(levelState.map);
 
   let objects = [];
@@ -567,7 +567,7 @@ function setTile(x,y, tile) {
 }
 
 // Maze generation
-function getGrid(width, height) {
+function getGridFunction(width, height) {
     var grid = [];
 
     for (let y = 0; y < height; y++) {


### PR DESCRIPTION
The game had the error "SyntaxError: unknown file: Cannot redeclare built-in function: getGrid (570:0)". I renamed the function, so it works now.