### PR TITLE
Kinda fix infinite loop prevention problem

### DIFF
--- a/src/lib/custom-babel-transforms.ts
+++ b/src/lib/custom-babel-transforms.ts
@@ -79,16 +79,18 @@ export default function TransformDetectInfiniteLoop({ types: t }: { types: any }
 				);
 
 				// No block statment e.g. `while (1) 1;`
-				if (!path.get('body').isBlockStatement()) {
+				const pathBodyAll = path.get('body');
+				const pathBody = Array.isArray(pathBodyAll) ? pathBodyAll[pathBodyAll.length - 1] : pathBodyAll;
+				if (!pathBody.isBlockStatement()) {
 					const statement = path.get('body').node;
-					path.get('body').replaceWith(
+					pathBody.replaceWith(
 						t.blockStatement([
 							guard,
 							statement,
 						]),
 					);
 				} else {
-					path.get('body').unshiftContainer('body', guard);
+					pathBody.unshiftContainer('body', guard);
 				}
 			}
 		}


### PR DESCRIPTION
The current loop prevention can fail for some weird code constructions, like this one:
```js
function __spreadArray(to, from, pack) {
    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
        if (ar || !(i in from)) {
            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
            ar[i] = from[i];
        }
    }
    return to.concat(ar || Array.prototype.slice.call(from));
}
```
This happens because the node `path` can have multiple bodies. Typically the main block is in the last entry of the array, which is why I'm choosing the last body node as the real one.