### PR TITLE
Add Sprig review automation workflow

### DIFF
--- a/.github/scripts/auto-triage.mjs
+++ b/.github/scripts/auto-triage.mjs
@@ -1,0 +1,491 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import {
+	REVIEW_BOT_MARKER,
+	addLabels,
+	ensureReviewLabels,
+	getIssueLabels,
+	getRepository,
+	githubPaginated,
+	hasLabel,
+	readGitHubEvent,
+	removeLabel,
+	setStateLabel,
+	upsertBotComment,
+} from "./review-utils.mjs";
+
+const token = process.env.GITHUB_TOKEN;
+if (!token) throw new Error("GITHUB_TOKEN is required");
+
+const { owner, repo } = getRepository();
+const event = readGitHubEvent();
+const pullRequest = event.pull_request;
+
+if (!pullRequest) {
+	console.log("No pull request in event; skipping auto triage.");
+	process.exit(0);
+}
+
+const prNumber = pullRequest.number;
+const workspace = path.resolve(process.env.SUBMISSION_PATH ?? process.cwd());
+const reviewBaseUrl = process.env.SPRIG_REVIEW_BASE_URL ?? "https://sprig.hackclub.com/editor";
+
+await ensureReviewLabels({ owner, repo, token });
+
+const labels = await getIssueLabels({ owner, repo, token, issueNumber: prNumber });
+if (!hasLabel(labels, "Submission")) {
+	console.log("Submission label missing; validation not needed yet.");
+	process.exit(0);
+}
+
+const pullFiles = await githubPaginated(token, `/repos/${owner}/${repo}/pulls/${prNumber}/files`);
+const result = validateSubmission({
+	pullRequest,
+	pullFiles,
+	workspace,
+	reviewBaseUrl,
+	owner,
+	repo,
+});
+
+await applyLabels(result);
+await upsertBotComment({
+	owner,
+	repo,
+	token,
+	issueNumber: prNumber,
+	marker: REVIEW_BOT_MARKER,
+	body: buildComment(result),
+});
+
+if (!result.ok) process.exit(1);
+
+function validateSubmission({ pullRequest, pullFiles, workspace, reviewBaseUrl, owner, repo }) {
+	const checks = [];
+	const problems = [];
+	const warnings = [];
+
+	const addCheck = (name, ok, detail) => {
+		checks.push({ name, ok, detail });
+		if (!ok && detail) problems.push(detail);
+	};
+
+	const jsFiles = pullFiles.filter((file) => file.filename.startsWith("games/") && file.filename.endsWith(".js"));
+	const imageFiles = pullFiles.filter((file) => /\.(png|jpe?g|webp)$/i.test(file.filename));
+	const disallowedFiles = pullFiles.filter((file) => !isAllowedSubmissionFile(file.filename));
+
+	addCheck(
+		"Files stay in allowed folders",
+		disallowedFiles.length === 0,
+		disallowedFiles.length
+			? `Only game files in \`games/\` and optional images in \`games/img/\` are allowed. Found ${disallowedFiles.map((file) => `\`${file.filename}\``).join(", ")}.`
+			: "Only submission files changed."
+	);
+
+	addCheck(
+		"Exactly one game file",
+		jsFiles.length === 1,
+		jsFiles.length === 0
+			? "Add exactly one JavaScript game file in `games/`."
+			: `Only one game file is allowed per submission. Found ${jsFiles.map((file) => `\`${file.filename}\``).join(", ")}.`
+	);
+
+	const changedNonAdded = pullFiles.filter((file) => file.status !== "added");
+	addCheck(
+		"Only new files added",
+		changedNonAdded.length === 0,
+		changedNonAdded.length
+			? `Submissions should add new files only. These files were not added: ${changedNonAdded.map((file) => `\`${file.filename}\``).join(", ")}.`
+			: "All submitted files are new."
+	);
+
+	const bodyChecks = validatePullRequestBody(pullRequest.body ?? "", imageFiles.length > 0);
+	for (const check of bodyChecks.checks) addCheck(check.name, check.ok, check.detail);
+
+	let gameFile = null;
+	let metadata = null;
+	let rawUrl = null;
+	let playUrl = null;
+	let screenshotUrl = null;
+	let similarity = { score: 0, match: null };
+
+	if (jsFiles.length === 1) {
+		gameFile = jsFiles[0];
+		const filename = path.basename(gameFile.filename);
+		const gamePath = path.join(workspace, gameFile.filename);
+		const content = readFileSafe(gamePath);
+
+		addCheck(
+			"Filename uses safe characters",
+			/^[a-zA-Z0-9_-]+\.js$/.test(filename),
+			/^[a-zA-Z0-9_-]+\.js$/.test(filename)
+				? "Filename is safe."
+				: `Rename \`${filename}\` to use only letters, numbers, \`-\`, and \`_\`.`
+		);
+
+		addCheck(
+			"Game file is directly inside games/",
+			path.dirname(gameFile.filename) === "games",
+			path.dirname(gameFile.filename) === "games"
+				? "Game file is in `games/`."
+				: `Move \`${gameFile.filename}\` directly into \`games/\`, not a nested folder.`
+		);
+
+		if (content === null) {
+			addCheck("Game file readable", false, `Unable to read \`${gameFile.filename}\` from the checked-out PR.`);
+		} else {
+			metadata = validateMetadata(content, filename, workspace);
+			for (const check of metadata.checks) addCheck(check.name, check.ok, check.detail);
+
+			const unsupportedApis = [/document\./i, /window\./i, /alert\(/i, /fetch\(/i].filter((regex) => regex.test(content));
+			addCheck(
+				"Sprig-only APIs",
+				unsupportedApis.length === 0,
+				unsupportedApis.length
+					? `Remove browser APIs like \`window\`, \`document\`, \`alert\`, or \`fetch\` from \`${filename}\`.`
+					: "No unsupported browser APIs found."
+			);
+
+			similarity = findMostSimilarGame(content, gameFile.filename, workspace);
+			if (similarity.score >= 0.5) {
+				warnings.push(`Similarity is ${formatPercent(similarity.score)} against \`${similarity.match}\`. A reviewer or lead should compare both games.`);
+			}
+		}
+
+		rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${pullRequest.head.sha}/${gameFile.filename}`;
+		const reviewUrl = new URL(reviewBaseUrl);
+		reviewUrl.searchParams.set("review", "true");
+		reviewUrl.searchParams.set("raw", rawUrl);
+		reviewUrl.searchParams.set("pr", String(prNumber));
+		reviewUrl.searchParams.set("repo", `${owner}/${repo}`);
+		playUrl = reviewUrl.toString();
+	}
+
+	if (gameFile) {
+		const gameBase = path.basename(gameFile.filename, ".js");
+		const badImagePaths = imageFiles.filter((file) => !file.filename.startsWith("games/img/"));
+		const mismatchedImages = imageFiles.filter((file) => path.basename(file.filename, path.extname(file.filename)) !== gameBase);
+
+		addCheck(
+			"Optional image path",
+			badImagePaths.length === 0,
+			badImagePaths.length
+				? `Move images into \`games/img/\`: ${badImagePaths.map((file) => `\`${file.filename}\``).join(", ")}.`
+				: imageFiles.length ? "Image files are in `games/img/`." : "No image provided; this is OK."
+		);
+
+		addCheck(
+			"Optional image name",
+			mismatchedImages.length === 0,
+			mismatchedImages.length
+				? `Image filename must match \`${gameBase}.js\`. Found ${mismatchedImages.map((file) => `\`${file.filename}\``).join(", ")}.`
+				: imageFiles.length ? "Image filename matches the game file." : "No image provided; gallery thumbnail can be generated/default."
+		);
+
+		if (imageFiles.length > 0) {
+			const image = imageFiles.find((file) => path.basename(file.filename, path.extname(file.filename)) === gameBase) ?? imageFiles[0];
+			screenshotUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${pullRequest.head.sha}/${image.filename}`;
+		}
+	}
+
+	const ok = checks.every((check) => check.ok);
+	return {
+		ok,
+		checks,
+		problems,
+		warnings,
+		metadata: metadata?.values ?? null,
+		gameFile: gameFile?.filename ?? null,
+		rawUrl,
+		playUrl,
+		screenshotUrl,
+		similarity,
+	};
+}
+
+function isAllowedSubmissionFile(filename) {
+	if (/^games\/[A-Za-z0-9_-]+\.js$/.test(filename)) return true;
+	if (/^games\/img\/[^/]+\.(png|jpe?g|webp)$/i.test(filename)) return true;
+	return false;
+}
+
+function validatePullRequestBody(body, imageProvided) {
+	const checks = [];
+	const add = (name, ok, detail) => checks.push({ name, ok, detail });
+
+	const author = extractBoldField(body, "Author");
+	const about = extractBoldField(body, "What is your game about?");
+	const gameplay = extractBoldField(body, "How do you play your game?");
+
+	add("PR author name", Boolean(author), author ? "Author field is filled." : "Fill in the `Author:` field in the PR description.");
+	add("PR about blurb", Boolean(about), about ? "About blurb is filled." : "Fill in `What is your game about?` in the PR description.");
+	add("PR gameplay description", Boolean(gameplay), gameplay ? "Gameplay description is filled." : "Fill in `How do you play your game?` in the PR description.");
+
+	const imageHeaderIndex = body.search(/^##\s+Image/im);
+	const codeSection = imageHeaderIndex >= 0 ? body.slice(0, imageHeaderIndex) : body;
+	const imageSection = imageHeaderIndex >= 0 ? body.slice(imageHeaderIndex) : "";
+
+	const codeBoxes = getCheckboxes(codeSection);
+	const uncheckedCodeBoxes = codeBoxes.filter((box) => !box.checked);
+	add(
+		"Code checklist",
+		codeBoxes.length > 0 && uncheckedCodeBoxes.length === 0,
+		codeBoxes.length === 0
+			? "Keep the PR checklist and check every required code box."
+			: uncheckedCodeBoxes.length
+				? `Check every required code box. Still unchecked: ${uncheckedCodeBoxes.map((box) => `\`${box.text}\``).join(", ")}.`
+				: "All required code boxes are checked."
+	);
+
+	if (imageProvided) {
+		const imageBoxes = getCheckboxes(imageSection);
+		const uncheckedImageBoxes = imageBoxes.filter((box) => !box.checked);
+		add(
+			"Image checklist",
+			imageBoxes.length > 0 && uncheckedImageBoxes.length === 0,
+			imageBoxes.length === 0
+				? "An image was added, so keep and complete the image checklist."
+				: uncheckedImageBoxes.length
+					? `Image was added, so check the image checklist boxes. Still unchecked: ${uncheckedImageBoxes.map((box) => `\`${box.text}\``).join(", ")}.`
+					: "Image checklist is checked."
+		);
+	} else {
+		add("Image checklist", true, "No image was added, so image checklist is optional.");
+	}
+
+	return { checks };
+}
+
+function extractBoldField(body, label) {
+	const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const pattern = new RegExp(`\\*\\*${escaped}:?\\*\\*\\s*([\\s\\S]*?)(?=\\n\\s*(?:\\*\\*|##|#)|$)`, "i");
+	const match = body.match(pattern);
+	if (!match) return "";
+	return stripTemplateNoise(match[1]);
+}
+
+function stripTemplateNoise(value) {
+	return value
+		.replace(/<!--[\s\S]*?-->/g, "")
+		.replace(/^>\s?.*$/gm, "")
+		.trim();
+}
+
+function getCheckboxes(markdown) {
+	return [...markdown.matchAll(/^\s*-\s+\[([ xX])\]\s+(.+)$/gm)].map((match) => ({
+		checked: match[1].toLowerCase() === "x",
+		text: match[2].replace(/<!--[\s\S]*?-->/g, "").trim(),
+	}));
+}
+
+function validateMetadata(content, filename, workspace) {
+	const checks = [];
+	const values = {
+		title: getMetadataValue(content, "title"),
+		author: getMetadataValue(content, "author"),
+		description: getMetadataValue(content, "description"),
+		tags: getMetadataValue(content, "tags"),
+		addedOn: getMetadataValue(content, "addedOn"),
+	};
+
+	const add = (name, ok, detail) => checks.push({ name, ok, detail });
+
+	for (const [key, value] of Object.entries(values)) {
+		add(
+			`Metadata @${key}`,
+			Boolean(value),
+			value ? `@${key} is filled.` : `Metadata in \`${filename}\` is missing or has empty \`@${key}:\`.`
+		);
+	}
+
+	const parsedTags = parseTags(values.tags);
+	add(
+		"Metadata tags parse",
+		Array.isArray(parsedTags) && parsedTags.length > 0,
+		Array.isArray(parsedTags) && parsedTags.length > 0
+			? "Tags are a non-empty array."
+			: `Set \`@tags:\` to a non-empty array, for example \`@tags: ['maze']\`.`
+	);
+
+	const validDate = /^\d{4}-\d{2}-\d{2}$/.test(values.addedOn);
+	const parsedDate = validDate ? new Date(`${values.addedOn}T00:00:00Z`) : null;
+	const now = new Date();
+	const tooOld = parsedDate ? Math.abs(now.getTime() - parsedDate.getTime()) > 183 * 86_400_000 : true;
+	add(
+		"Metadata date",
+		validDate && parsedDate && !Number.isNaN(parsedDate.getTime()) && !tooOld,
+		validDate && parsedDate && !Number.isNaN(parsedDate.getTime()) && !tooOld
+			? "Date looks current."
+			: `Set \`@addedOn:\` to a recent date in \`YYYY-MM-DD\` format.`
+	);
+
+	const titleLooksLikeTemplate = /getting_started/i.test(values.title) || /template/i.test(values.title);
+	const authorLooksLikeTemplate = /leo,\s*edits/i.test(values.author);
+	add(
+		"Metadata template values",
+		!titleLooksLikeTemplate && !authorLooksLikeTemplate,
+		!titleLooksLikeTemplate && !authorLooksLikeTemplate
+			? "No template metadata values found."
+			: "Replace example/template values in the metadata header."
+	);
+
+	const titleConflict = values.title ? findTitleConflict(values.title, filename, workspace) : null;
+	add(
+		"Unique game title",
+		!titleConflict,
+		titleConflict
+			? `Game title \`${values.title}\` already appears in \`${titleConflict}\`; choose a unique title.`
+			: "Game title appears unique."
+	);
+
+	return { checks, values: { ...values, tags: parsedTags ?? values.tags } };
+}
+
+function getMetadataValue(content, key) {
+	const match = content.match(new RegExp(`@${key}:\\s*([^\\r\\n]*)`));
+	return match?.[1]?.trim() ?? "";
+}
+
+function parseTags(value) {
+	if (!value) return null;
+	try {
+		return JSON.parse(value.replaceAll("'", "\""));
+	} catch {
+		return null;
+	}
+}
+
+function findTitleConflict(title, filename, workspace) {
+	const gamesDir = path.join(workspace, "games");
+	const normalizedTitle = normalize(title);
+	for (const gameFile of readdirSync(gamesDir).filter((file) => file.endsWith(".js"))) {
+		if (gameFile === filename) continue;
+		const content = readFileSafe(path.join(gamesDir, gameFile));
+		if (!content) continue;
+		const existingTitle = getMetadataValue(content, "title");
+		if (normalize(existingTitle) === normalizedTitle) return `games/${gameFile}`;
+	}
+	return null;
+}
+
+function normalize(value) {
+	return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function findMostSimilarGame(content, submittedFilename, workspace) {
+	const gamesDir = path.join(workspace, "games");
+	const gameFiles = readdirSync(gamesDir).filter((file) => file.endsWith(".js"));
+	let best = { score: 0, match: null };
+	for (const gameFile of gameFiles) {
+		const relativePath = `games/${gameFile}`;
+		if (relativePath === submittedFilename) continue;
+		const other = readFileSafe(path.join(gamesDir, gameFile));
+		if (!other) continue;
+		const score = checkSimilarity(content, other);
+		if (score > best.score) best = { score, match: relativePath };
+	}
+	return best;
+}
+
+function analyze(code) {
+	return code
+		.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, "")
+		.replace(/bitmap`[\s\S]*?`/g, "")
+		.replace(/map`[\s\S]*?`/g, "")
+		.replace(/tune`[\s\S]*?`/g, "")
+		.replace(/\b(let|const|var)\s+\w+/g, "$1 VAR")
+		.replace(/\s+/g, "")
+		.toLowerCase();
+}
+
+function checkSimilarity(a, b) {
+	const s1 = analyze(a);
+	const s2 = analyze(b);
+	const chunks = (value) => {
+		const set = new Set();
+		for (let i = 0; i <= value.length - 10; i += 1) set.add(value.slice(i, i + 10));
+		return set;
+	};
+	const c1 = chunks(s1);
+	const c2 = chunks(s2);
+	if (!c1.size || !c2.size) return 0;
+	let overlap = 0;
+	for (const chunk of c1) {
+		if (c2.has(chunk)) overlap += 1;
+	}
+	return (2 * overlap) / (c1.size + c2.size);
+}
+
+function readFileSafe(filePath) {
+	try {
+		return readFileSync(filePath, "utf8");
+	} catch {
+		return null;
+	}
+}
+
+async function applyLabels(result) {
+	await addLabels({ owner, repo, token, issueNumber: prNumber, labels: ["Submission"] });
+
+	if (result.ok) {
+		await addLabels({ owner, repo, token, issueNumber: prNumber, labels: ["Verified"] });
+		await setStateLabel({ owner, repo, token, issueNumber: prNumber, state: "Ready for Playtest" });
+		await removeLabel({ owner, repo, token, issueNumber: prNumber, label: "Failed" });
+		await removeLabel({ owner, repo, token, issueNumber: prNumber, label: "Needs Author" });
+	} else {
+		await addLabels({ owner, repo, token, issueNumber: prNumber, labels: ["Failed"] });
+		await setStateLabel({ owner, repo, token, issueNumber: prNumber, state: "Needs Author" });
+		await removeLabel({ owner, repo, token, issueNumber: prNumber, label: "Verified" });
+		await removeLabel({ owner, repo, token, issueNumber: prNumber, label: "Ready for Playtest" });
+		await removeLabel({ owner, repo, token, issueNumber: prNumber, label: "Ready for Maintainer" });
+	}
+
+	if (result.similarity.score >= 0.5) {
+		await addLabels({ owner, repo, token, issueNumber: prNumber, labels: ["Plagiarism Risk"] });
+	} else {
+		await removeLabel({ owner, repo, token, issueNumber: prNumber, label: "Plagiarism Risk" });
+	}
+}
+
+function buildComment(result) {
+	const status = result.ok ? "✅ Auto Review: Verified" : "❌ Auto Review: Needs Fixes";
+	const metadata = result.metadata ?? {};
+	const checkLines = result.checks.map((check) => {
+		const icon = check.ok ? "✅" : "❌";
+		return `- ${icon} ${check.name}: ${check.detail}`;
+	});
+
+	const links = [];
+	if (result.playUrl) links.push(`- [Play in Sprig Editor](${result.playUrl})`);
+	if (result.rawUrl) links.push(`- [View Raw](${result.rawUrl})`);
+	if (result.screenshotUrl) links.push(`- [View Screenshot](${result.screenshotUrl})`);
+	links.push(`- [PR Files](${pullRequest.html_url}/files)`);
+
+	const warningLines = result.warnings.length
+		? ["", "#### Review Flags", ...result.warnings.map((warning) => `- ⚠️ ${warning}`)]
+		: [];
+
+	return `${REVIEW_BOT_MARKER}
+### ${status}
+
+${result.ok ? "This submission is ready for human playtest." : "This submission needs author fixes before normal review."}
+
+#### Submission
+- Game: ${metadata.title ? `\`${metadata.title}\`` : "unknown"}
+- Author: ${metadata.author ? `\`${metadata.author}\`` : "unknown"}
+- File: ${result.gameFile ? `\`${result.gameFile}\`` : "not found"}
+- Similarity: ${formatPercent(result.similarity.score)}${result.similarity.match ? ` against \`${result.similarity.match}\`` : ""}
+
+#### Links
+${links.join("\n")}
+
+#### Checks
+${checkLines.join("\n")}${warningLines.join("\n")}
+
+${result.ok ? "Reviewers: claim this PR, use the play link, then approve or request changes." : "Authors: push fixes to this PR. These checks rerun automatically."}
+`;
+}
+
+function formatPercent(value) {
+	return `${Math.round(value * 100)}%`;
+}

--- a/.github/scripts/review-commands.mjs
+++ b/.github/scripts/review-commands.mjs
@@ -1,0 +1,132 @@
+import {
+	addLabels,
+	ensureReviewLabels,
+	getIssueLabels,
+	getRepository,
+	githubRequest,
+	hasLabel,
+	readGitHubEvent,
+	removeLabel,
+	setStateLabel,
+} from "./review-utils.mjs";
+
+const token = process.env.GITHUB_TOKEN;
+if (!token) throw new Error("GITHUB_TOKEN is required");
+
+const event = readGitHubEvent();
+const issue = event.issue;
+const comment = event.comment;
+
+if (!issue || !comment || !issue.pull_request) {
+	console.log("No pull request comment found; skipping commands.");
+	process.exit(0);
+}
+
+const body = comment.body.trim();
+if (!body.startsWith("/")) {
+	console.log("No review command found.");
+	process.exit(0);
+}
+
+const { owner, repo } = getRepository();
+const issueNumber = issue.number;
+const actor = comment.user.login;
+
+await ensureReviewLabels({ owner, repo, token });
+
+const [command, ...rest] = body.split(/\s+/);
+const text = rest.join(" ").trim();
+
+switch (command.toLowerCase()) {
+	case "/claim":
+		await claim();
+		break;
+	case "/unclaim":
+		await unclaim();
+		break;
+	case "/triage-note":
+		await triageNote(text);
+		break;
+	case "/needs-author":
+		await needsAuthor(text);
+		break;
+	case "/ready-maintainer":
+		await readyMaintainer(text);
+		break;
+	case "/ai-concern":
+		await aiConcern(text);
+		break;
+	case "/plagiarism-risk":
+		await plagiarismRisk(text);
+		break;
+	default:
+		console.log(`Unknown review command: ${command}`);
+}
+
+async function claim() {
+	await githubRequest(token, "POST", `/repos/${owner}/${repo}/issues/${issueNumber}/assignees`, {
+		assignees: [actor],
+	});
+	await addLabels({ owner, repo, token, issueNumber, labels: ["Claimed"] });
+	await reply(`Claimed by @${actor}.`);
+}
+
+async function unclaim() {
+	await githubRequest(token, "DELETE", `/repos/${owner}/${repo}/issues/${issueNumber}/assignees`, {
+		assignees: [actor],
+	});
+	const issueData = await githubRequest(token, "GET", `/repos/${owner}/${repo}/issues/${issueNumber}`);
+	if ((issueData.assignees ?? []).length === 0) {
+		await removeLabel({ owner, repo, token, issueNumber, label: "Claimed" });
+	}
+	await reply(`Unclaimed by @${actor}.`);
+}
+
+async function triageNote(text) {
+	if (!text) {
+		await reply("Add note text after `/triage-note`.");
+		return;
+	}
+	await addLabels({ owner, repo, token, issueNumber, labels: ["Triaged"] });
+	await reply(`Triage note saved for Sheet sync.`);
+}
+
+async function needsAuthor(text) {
+	await addLabels({ owner, repo, token, issueNumber, labels: ["Triaged"] });
+	await setStateLabel({ owner, repo, token, issueNumber, state: "Needs Author" });
+	await removeLabel({ owner, repo, token, issueNumber, label: "Claimed" });
+	const suffix = text ? `\n\nReason: ${text}` : "";
+	await reply(`Marked as Needs Author.${suffix}`);
+}
+
+async function readyMaintainer(text) {
+	const labels = await getIssueLabels({ owner, repo, token, issueNumber });
+	if (hasLabel(labels, "Failed")) {
+		await reply("Cannot mark Ready for Maintainer while Failed label is present. Fix auto-review issues first.");
+		return;
+	}
+	await addLabels({ owner, repo, token, issueNumber, labels: ["Triaged"] });
+	await setStateLabel({ owner, repo, token, issueNumber, state: "Ready for Maintainer" });
+	await removeLabel({ owner, repo, token, issueNumber, label: "Claimed" });
+	const suffix = text ? `\n\nNote: ${text}` : "";
+	await reply(`Marked as Ready for Maintainer.${suffix}`);
+}
+
+async function aiConcern(text) {
+	await addLabels({ owner, repo, token, issueNumber, labels: ["AI Concern", "Triaged"] });
+	await setStateLabel({ owner, repo, token, issueNumber, state: "Needs Author" });
+	const suffix = text ? `\n\nReason: ${text}` : "";
+	await reply(`Marked with AI Concern.${suffix}`);
+}
+
+async function plagiarismRisk(text) {
+	await addLabels({ owner, repo, token, issueNumber, labels: ["Plagiarism Risk", "Triaged"] });
+	const suffix = text ? `\n\nReason: ${text}` : "";
+	await reply(`Marked with Plagiarism Risk.${suffix}`);
+}
+
+async function reply(message) {
+	await githubRequest(token, "POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+		body: `<!-- sprig-review-command -->\n${message}`,
+	});
+}

--- a/.github/scripts/review-utils.mjs
+++ b/.github/scripts/review-utils.mjs
@@ -1,0 +1,263 @@
+import { readFileSync } from "node:fs";
+
+export const LABELS = {
+	Submission: {
+		color: "6f42c1",
+		description: "Game submission that should be processed by review automation",
+		aliases: ["submission"],
+	},
+	Verified: {
+		color: "2da44e",
+		description: "Automated submission checks passed",
+		aliases: ["submission:verified"],
+	},
+	Failed: {
+		color: "d1242f",
+		description: "Automated submission checks failed",
+		aliases: ["submission:failed"],
+	},
+	"Ready for Playtest": {
+		color: "0969da",
+		description: "Ready for a reviewer to playtest",
+		aliases: ["queue:playtest"],
+	},
+	"Needs Author": {
+		color: "fbca04",
+		description: "Waiting for the PR author to make changes",
+		aliases: ["needs:author"],
+	},
+	Triaged: {
+		color: "bf8700",
+		description: "A human reviewer has looked at this submission",
+		aliases: ["triaged"],
+	},
+	"Ready for Maintainer": {
+		color: "2da44e",
+		description: "Human review passed; maintainer should check and merge",
+		aliases: ["ready:maintainer"],
+	},
+	"Plagiarism Risk": {
+		color: "cf222e",
+		description: "Similarity checker or reviewer found possible plagiarism",
+		aliases: ["plagiarism:risk"],
+	},
+	"AI Concern": {
+		color: "bf3989",
+		description: "Reviewer needs author to explain AI usage",
+		aliases: ["review:ai-concern"],
+	},
+	"Potential Duplicate": {
+		color: "8250df",
+		description: "Author has more than one open submission",
+		aliases: ["potential-duplicate"],
+	},
+	"Keep Open": {
+		color: "8c959f",
+		description: "Stale automation should not close this PR",
+		aliases: ["keep-open"],
+	},
+	Stale: {
+		color: "6e7781",
+		description: "No activity for long enough that the PR needs attention",
+		aliases: ["stale"],
+	},
+	Claimed: {
+		color: "54aeff",
+		description: "A reviewer has claimed this submission",
+		aliases: ["review:claimed"],
+	},
+};
+
+export const STATE_LABELS = [
+	"Ready for Playtest",
+	"Needs Author",
+	"Ready for Maintainer",
+	"Stale",
+];
+
+export const REVIEW_BOT_MARKER = "<!-- sprig-auto-review -->";
+export const STALE_REMINDER_MARKER = "<!-- sprig-stale-reminder -->";
+export const MAINTAINER_REMINDER_MARKER = "<!-- sprig-maintainer-reminder -->";
+
+export function getRepository() {
+	const value = process.env.GITHUB_REPOSITORY;
+	if (!value || !value.includes("/")) {
+		throw new Error("GITHUB_REPOSITORY must be set to owner/repo");
+	}
+	const [owner, repo] = value.split("/");
+	return { owner, repo };
+}
+
+export function readGitHubEvent() {
+	const eventPath = process.env.GITHUB_EVENT_PATH;
+	if (!eventPath) return {};
+	return JSON.parse(readFileSync(eventPath, "utf8"));
+}
+
+export async function githubRequest(token, method, route, body) {
+	const response = await fetch(`https://api.github.com${route}`, {
+		method,
+		headers: {
+			Accept: "application/vnd.github+json",
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+			"X-GitHub-Api-Version": "2022-11-28",
+		},
+		body: body === undefined ? undefined : JSON.stringify(body),
+	});
+
+	if (response.status === 204) return null;
+
+	const text = await response.text();
+	const data = text ? JSON.parse(text) : null;
+	if (!response.ok) {
+		const message = data?.message ?? text ?? `${response.status}`;
+		throw new Error(`${method} ${route} failed: ${message}`);
+	}
+	return data;
+}
+
+export async function githubPaginated(token, route) {
+	const results = [];
+	let page = 1;
+	for (;;) {
+		const joiner = route.includes("?") ? "&" : "?";
+		const data = await githubRequest(token, "GET", `${route}${joiner}per_page=100&page=${page}`);
+		if (!Array.isArray(data) || data.length === 0) break;
+		results.push(...data);
+		if (data.length < 100) break;
+		page += 1;
+	}
+	return results;
+}
+
+export async function ensureReviewLabels({ owner, repo, token }) {
+	const existing = await githubPaginated(token, `/repos/${owner}/${repo}/labels`);
+	const byLowerName = new Map(existing.map((label) => [label.name.toLowerCase(), label]));
+
+	for (const [name, config] of Object.entries(LABELS)) {
+		const exact = byLowerName.get(name.toLowerCase());
+		if (exact) {
+			await updateLabelIfNeeded({ owner, repo, token, currentName: exact.name, name, config });
+			continue;
+		}
+
+		const alias = config.aliases
+			.map((aliasName) => byLowerName.get(aliasName.toLowerCase()))
+			.find(Boolean);
+
+		if (alias) {
+			await updateLabelIfNeeded({ owner, repo, token, currentName: alias.name, name, config });
+			continue;
+		}
+
+		try {
+			const created = await githubRequest(token, "POST", `/repos/${owner}/${repo}/labels`, {
+				name,
+				color: config.color,
+				description: config.description,
+			});
+			byLowerName.set(created.name.toLowerCase(), created);
+		} catch (error) {
+			if (!String(error.message).includes("already_exists")) throw error;
+		}
+	}
+}
+
+async function updateLabelIfNeeded({ owner, repo, token, currentName, name, config }) {
+	try {
+		await githubRequest(token, "PATCH", `/repos/${owner}/${repo}/labels/${encodeURIComponent(currentName)}`, {
+			new_name: name,
+			color: config.color,
+			description: config.description,
+		});
+	} catch (error) {
+		if (!String(error.message).includes("already_exists")) throw error;
+	}
+}
+
+export async function getIssueLabels({ owner, repo, token, issueNumber }) {
+	const issue = await githubRequest(token, "GET", `/repos/${owner}/${repo}/issues/${issueNumber}`);
+	return (issue.labels ?? []).map((label) => typeof label === "string" ? label : label.name);
+}
+
+export function hasLabel(labels, name) {
+	return labels.some((label) => label.toLowerCase() === name.toLowerCase());
+}
+
+export async function addLabels({ owner, repo, token, issueNumber, labels }) {
+	if (!labels.length) return;
+	await githubRequest(token, "POST", `/repos/${owner}/${repo}/issues/${issueNumber}/labels`, { labels });
+}
+
+export async function removeLabel({ owner, repo, token, issueNumber, label }) {
+	try {
+		await githubRequest(token, "DELETE", `/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(label)}`);
+	} catch (error) {
+		if (!String(error.message).includes("Label does not exist")) throw error;
+	}
+}
+
+export async function removeLabels({ owner, repo, token, issueNumber, labels }) {
+	for (const label of labels) {
+		await removeLabel({ owner, repo, token, issueNumber, label });
+	}
+}
+
+export async function setStateLabel({ owner, repo, token, issueNumber, state }) {
+	const labels = await getIssueLabels({ owner, repo, token, issueNumber });
+	const labelsToRemove = STATE_LABELS.filter((label) => label !== state && hasLabel(labels, label));
+	await removeLabels({ owner, repo, token, issueNumber, labels: labelsToRemove });
+	await addLabels({ owner, repo, token, issueNumber, labels: [state] });
+}
+
+export function currentStateFromLabels(labels, pullRequest) {
+	if (pullRequest?.merged_at) return "Merged";
+	if (pullRequest?.closed_at) return "Closed";
+	if (hasLabel(labels, "Claimed")) return "Claimed";
+	for (const state of STATE_LABELS) {
+		if (hasLabel(labels, state)) return state;
+	}
+	if (hasLabel(labels, "Failed")) return "Needs Author";
+	if (hasLabel(labels, "Verified")) return "Verified";
+	return "Unsorted";
+}
+
+export function nextActionFromState(state, labels) {
+	if (hasLabel(labels, "Plagiarism Risk")) return "Lead plagiarism review";
+	if (hasLabel(labels, "AI Concern")) return "Lead AI review";
+	switch (state) {
+		case "Ready for Playtest":
+			return "Reviewer playtest";
+		case "Claimed":
+			return "Reviewer playtest";
+		case "Needs Author":
+		case "Failed":
+			return "Author fix";
+		case "Ready for Maintainer":
+			return "Maintainer merge";
+		case "Stale":
+			return "Close or reopen";
+		default:
+			return "None";
+	}
+}
+
+export async function upsertBotComment({ owner, repo, token, issueNumber, marker, body }) {
+	const comments = await githubPaginated(token, `/repos/${owner}/${repo}/issues/${issueNumber}/comments`);
+	const existing = comments.find((comment) => comment.user?.type === "Bot" && comment.body?.includes(marker));
+	const fullBody = body.includes(marker) ? body : `${marker}\n${body}`;
+	if (existing) {
+		await githubRequest(token, "PATCH", `/repos/${owner}/${repo}/issues/comments/${existing.id}`, { body: fullBody });
+		return existing.id;
+	}
+
+	const created = await githubRequest(token, "POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+		body: fullBody,
+	});
+	return created.id;
+}
+
+export function daysBetween(start, end = new Date()) {
+	return Math.floor((end.getTime() - new Date(start).getTime()) / 86_400_000);
+}

--- a/.github/scripts/stale-review-queue.mjs
+++ b/.github/scripts/stale-review-queue.mjs
@@ -1,0 +1,114 @@
+import {
+	MAINTAINER_REMINDER_MARKER,
+	STALE_REMINDER_MARKER,
+	daysBetween,
+	ensureReviewLabels,
+	getIssueLabels,
+	getRepository,
+	githubPaginated,
+	githubRequest,
+	hasLabel,
+	removeLabel,
+	setStateLabel,
+} from "./review-utils.mjs";
+
+const token = process.env.GITHUB_TOKEN;
+if (!token) throw new Error("GITHUB_TOKEN is required");
+
+const { owner, repo } = getRepository();
+await ensureReviewLabels({ owner, repo, token });
+
+const openPulls = await githubPaginated(token, `/repos/${owner}/${repo}/pulls?state=open&sort=updated&direction=asc`);
+
+for (const pullRequest of openPulls) {
+	const issueNumber = pullRequest.number;
+	const labels = await getIssueLabels({ owner, repo, token, issueNumber });
+	if (!hasLabel(labels, "Submission")) continue;
+	if (hasLabel(labels, "Keep Open")) continue;
+
+	if (hasLabel(labels, "Needs Author") || hasLabel(labels, "Failed") || hasLabel(labels, "Stale")) {
+		await handleNeedsAuthor(pullRequest, labels);
+		continue;
+	}
+
+	if (hasLabel(labels, "Ready for Maintainer")) {
+		await handleReadyForMaintainer(pullRequest);
+		continue;
+	}
+
+	if (hasLabel(labels, "Claimed")) {
+		await handleClaimed(pullRequest);
+	}
+}
+
+async function handleNeedsAuthor(pullRequest, labels) {
+	const needsAuthorSince = await latestLabelTime(pullRequest.number, "Needs Author");
+	const failedSince = await latestLabelTime(pullRequest.number, "Failed");
+	const since = newestDate([needsAuthorSince, failedSince].filter(Boolean));
+	if (!since) return;
+
+	const age = daysBetween(since);
+	if (age >= 14 && !hasLabel(labels, "Plagiarism Risk")) {
+		await commentOnce({
+			issueNumber: pullRequest.number,
+			marker: "<!-- sprig-auto-close -->",
+			body: "Closing because this submission has been waiting on author changes for 14 days. Push fixes and ask a reviewer to reopen when ready.",
+		});
+		await githubRequest(token, "PATCH", `/repos/${owner}/${repo}/issues/${pullRequest.number}`, {
+			state: "closed",
+		});
+		return;
+	}
+
+	if (age >= 7) {
+		await setStateLabel({ owner, repo, token, issueNumber: pullRequest.number, state: "Stale" });
+		await commentOnce({
+			issueNumber: pullRequest.number,
+			marker: STALE_REMINDER_MARKER,
+			body: "This submission has been waiting on author changes for 7 days. Please push fixes soon, or it may be closed after 14 days of no response.",
+		});
+	}
+}
+
+function newestDate(dates) {
+	return dates
+		.sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0] ?? null;
+}
+
+async function handleReadyForMaintainer(pullRequest) {
+	const since = await latestLabelTime(pullRequest.number, "Ready for Maintainer");
+	if (!since || daysBetween(since) < 7) return;
+	await commentOnce({
+		issueNumber: pullRequest.number,
+		marker: MAINTAINER_REMINDER_MARKER,
+		body: "This submission has been ready for maintainer review for 7 days.",
+	});
+}
+
+async function handleClaimed(pullRequest) {
+	const since = await latestLabelTime(pullRequest.number, "Claimed");
+	if (!since || daysBetween(since) < 3) return;
+	await removeLabel({ owner, repo, token, issueNumber: pullRequest.number, label: "Claimed" });
+	await commentOnce({
+		issueNumber: pullRequest.number,
+		marker: "<!-- sprig-unclaim-stale -->",
+		body: "Unclaiming because this review has had no activity for 3 days.",
+	});
+}
+
+async function latestLabelTime(issueNumber, labelName) {
+	const events = await githubPaginated(token, `/repos/${owner}/${repo}/issues/${issueNumber}/events`);
+	const matching = events
+		.filter((event) => event.event === "labeled" && event.label?.name?.toLowerCase() === labelName.toLowerCase())
+		.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+	return matching[0]?.created_at ?? null;
+}
+
+async function commentOnce({ issueNumber, marker, body }) {
+	const comments = await githubPaginated(token, `/repos/${owner}/${repo}/issues/${issueNumber}/comments`);
+	const alreadyCommented = comments.some((comment) => comment.body?.includes(marker));
+	if (alreadyCommented) return;
+	await githubRequest(token, "POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+		body: `${marker}\n${body}`,
+	});
+}

--- a/.github/scripts/sync-review-sheet.mjs
+++ b/.github/scripts/sync-review-sheet.mjs
@@ -1,0 +1,304 @@
+import {
+	currentStateFromLabels,
+	daysBetween,
+	getRepository,
+	githubPaginated,
+	githubRequest,
+	hasLabel,
+	nextActionFromState,
+} from "./review-utils.mjs";
+
+const token = process.env.GITHUB_TOKEN;
+const spreadsheetId = process.env.GOOGLE_SHEET_ID;
+const serviceAccountJson = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+const mainTab = process.env.SPRIG_REVIEW_SHEET_TAB || "All";
+
+if (!token) throw new Error("GITHUB_TOKEN is required");
+if (!spreadsheetId || !serviceAccountJson) {
+	console.log("Google Sheet secrets not configured; skipping Sheet sync.");
+	process.exit(0);
+}
+
+const { owner, repo } = getRepository();
+const sheets = await makeSheetsClient(serviceAccountJson);
+
+const columns = [
+	"PR #",
+	"PR URL",
+	"Title",
+	"Submitter",
+	"State",
+	"Next Action",
+	"Triager",
+	"Reviewer",
+	"Review Decision",
+	"Triage Note",
+	"Internal Note",
+	"Age Days",
+	"Last Activity",
+	"Play Link",
+	"Raw Link",
+	"Screenshot Link",
+	"Similarity %",
+	"Labels",
+	"Merged At",
+	"Closed At",
+];
+
+await ensureSheets();
+const existingRows = await readExistingRows();
+const syncedRows = await buildRows(existingRows);
+await writeRows(syncedRows);
+await writeFilteredTabs();
+await writeMetrics();
+
+async function makeSheetsClient(rawCredentials) {
+	const { google } = await import("googleapis");
+	const credentials = parseCredentials(rawCredentials);
+	const auth = new google.auth.GoogleAuth({
+		credentials,
+		scopes: ["https://www.googleapis.com/auth/spreadsheets"],
+	});
+	return google.sheets({ version: "v4", auth });
+}
+
+function parseCredentials(value) {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+	}
+}
+
+async function ensureSheets() {
+	const spreadsheet = await sheets.spreadsheets.get({ spreadsheetId });
+	const existing = new Set(spreadsheet.data.sheets.map((sheet) => sheet.properties.title));
+	const requiredTabs = [
+		mainTab,
+		"Ready for Playtest",
+		"Claimed",
+		"Needs Author",
+		"Ready for Maintainer",
+		"Stale",
+		"Merged",
+		"Metrics",
+	];
+	const requests = requiredTabs
+		.filter((title) => !existing.has(title))
+		.map((title) => ({ addSheet: { properties: { title } } }));
+
+	if (requests.length) {
+		await sheets.spreadsheets.batchUpdate({ spreadsheetId, requestBody: { requests } });
+	}
+
+	await sheets.spreadsheets.values.update({
+		spreadsheetId,
+		range: quoteRange(mainTab, "A1"),
+		valueInputOption: "RAW",
+		requestBody: { values: [columns] },
+	});
+}
+
+async function readExistingRows() {
+	const response = await sheets.spreadsheets.values.get({
+		spreadsheetId,
+		range: quoteRange(mainTab, `A2:${columnLetter(columns.length)}10000`),
+	});
+	const rows = response.data.values ?? [];
+	const map = new Map();
+	for (const row of rows) {
+		const prNumber = Number(row[0]);
+		if (!Number.isFinite(prNumber)) continue;
+		map.set(prNumber, rowToObject(row));
+	}
+	return map;
+}
+
+function rowToObject(row) {
+	return Object.fromEntries(columns.map((column, index) => [column, row[index] ?? ""]));
+}
+
+async function buildRows(existingRows) {
+	const pulls = await collectPullRequests(existingRows);
+	const nextRows = new Map(existingRows);
+
+	for (const pullRequest of pulls) {
+		const issue = await githubRequest(token, "GET", `/repos/${owner}/${repo}/issues/${pullRequest.number}`);
+		const labels = (issue.labels ?? []).map((label) => label.name);
+		if (!hasLabel(labels, "Submission") && !existingRows.has(pullRequest.number)) continue;
+
+		const reviews = await githubPaginated(token, `/repos/${owner}/${repo}/pulls/${pullRequest.number}/reviews`);
+		const comments = await githubPaginated(token, `/repos/${owner}/${repo}/issues/${pullRequest.number}/comments`);
+		const state = currentStateFromLabels(labels, pullRequest);
+		const lastReview = latestReview(reviews);
+		const commandNote = latestReviewerNote(comments);
+		const autoReview = parseAutoReview(comments);
+		const existing = existingRows.get(pullRequest.number) ?? {};
+
+		nextRows.set(pullRequest.number, {
+			"PR #": pullRequest.number,
+			"PR URL": pullRequest.html_url,
+			Title: pullRequest.title,
+			Submitter: pullRequest.user.login,
+			State: state,
+			"Next Action": nextActionFromState(state, labels),
+			Triager: commandNote?.user ?? lastReview?.user?.login ?? existing.Triager ?? "",
+			Reviewer: (issue.assignees ?? []).map((user) => user.login).join(", "),
+			"Review Decision": formatReviewDecision(lastReview?.state ?? ""),
+			"Triage Note": commandNote?.text ?? existing["Triage Note"] ?? "",
+			"Internal Note": existing["Internal Note"] ?? "",
+			"Age Days": daysBetween(pullRequest.created_at),
+			"Last Activity": pullRequest.updated_at,
+			"Play Link": autoReview.playLink ?? existing["Play Link"] ?? "",
+			"Raw Link": autoReview.rawLink ?? existing["Raw Link"] ?? "",
+			"Screenshot Link": autoReview.screenshotLink ?? existing["Screenshot Link"] ?? "",
+			"Similarity %": autoReview.similarity ?? existing["Similarity %"] ?? "",
+			Labels: labels.join(", "),
+			"Merged At": pullRequest.merged_at ?? "",
+			"Closed At": pullRequest.closed_at ?? "",
+		});
+	}
+
+	return [...nextRows.values()].sort((a, b) => Number(a["PR #"]) - Number(b["PR #"]));
+}
+
+async function collectPullRequests(existingRows) {
+	const openPulls = await githubPaginated(token, `/repos/${owner}/${repo}/pulls?state=open&sort=created&direction=asc`);
+	const closedPulls = await githubPaginated(token, `/repos/${owner}/${repo}/pulls?state=closed&sort=updated&direction=desc`);
+	const recentCutoff = Date.now() - 90 * 86_400_000;
+	const pullMap = new Map();
+
+	for (const pullRequest of openPulls) pullMap.set(pullRequest.number, pullRequest);
+	for (const pullRequest of closedPulls) {
+		const isRecent = new Date(pullRequest.updated_at).getTime() > recentCutoff;
+		if (isRecent || existingRows.has(pullRequest.number)) {
+			pullMap.set(pullRequest.number, pullRequest);
+		}
+	}
+
+	return [...pullMap.values()];
+}
+
+function latestReview(reviews) {
+	return [...reviews]
+		.sort((a, b) => new Date(b.submitted_at).getTime() - new Date(a.submitted_at).getTime())
+		.find((review) => ["APPROVED", "CHANGES_REQUESTED", "COMMENTED"].includes(review.state));
+}
+
+function formatReviewDecision(state) {
+	switch (state) {
+		case "APPROVED":
+			return "Approved";
+		case "CHANGES_REQUESTED":
+			return "Changes Requested";
+		case "COMMENTED":
+			return "Commented";
+		default:
+			return "";
+	}
+}
+
+function latestReviewerNote(comments) {
+	const notes = comments
+		.map((comment) => {
+			const match = comment.body?.match(/^\/(triage-note|needs-author|ready-maintainer|ai-concern|plagiarism-risk)\s*([\s\S]*)/i);
+			if (!match) return null;
+			const text = match[2].trim();
+			if (!text) return null;
+			return {
+				text,
+				user: comment.user?.login ?? "",
+				createdAt: comment.created_at,
+			};
+		})
+		.filter(Boolean);
+
+	return notes.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0] ?? null;
+}
+
+function parseAutoReview(comments) {
+	const comment = [...comments]
+		.reverse()
+		.find((item) => item.body?.includes("<!-- sprig-auto-review -->"));
+	const body = comment?.body ?? "";
+	return {
+		playLink: firstMarkdownLink(body, "Play in Sprig Editor"),
+		rawLink: firstMarkdownLink(body, "View Raw"),
+		screenshotLink: firstMarkdownLink(body, "View Screenshot"),
+		similarity: body.match(/Similarity:\s*([0-9]+%)/)?.[1] ?? "",
+	};
+}
+
+function firstMarkdownLink(markdown, label) {
+	const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return markdown.match(new RegExp(`\\[${escaped}\\]\\(([^)]+)\\)`))?.[1] ?? "";
+}
+
+async function writeRows(rows) {
+	await sheets.spreadsheets.values.clear({
+		spreadsheetId,
+		range: quoteRange(mainTab, `A2:${columnLetter(columns.length)}10000`),
+	});
+	if (!rows.length) return;
+	await sheets.spreadsheets.values.update({
+		spreadsheetId,
+		range: quoteRange(mainTab, "A2"),
+		valueInputOption: "USER_ENTERED",
+		requestBody: { values: rows.map((row) => columns.map((column) => row[column] ?? "")) },
+	});
+}
+
+async function writeFilteredTabs() {
+	const filters = {
+		"Ready for Playtest": `E2:E="Ready for Playtest"`,
+		Claimed: `E2:E="Claimed"`,
+		"Needs Author": `E2:E="Needs Author"`,
+		"Ready for Maintainer": `E2:E="Ready for Maintainer"`,
+		Stale: `E2:E="Stale"`,
+		Merged: `E2:E="Merged"`,
+	};
+	const lastColumn = columnLetter(columns.length);
+	for (const [tab, condition] of Object.entries(filters)) {
+		const formula = `={'${mainTab}'!A1:${lastColumn}1; FILTER('${mainTab}'!A2:${lastColumn}, '${mainTab}'!${condition})}`;
+		await sheets.spreadsheets.values.update({
+			spreadsheetId,
+			range: quoteRange(tab, "A1"),
+			valueInputOption: "USER_ENTERED",
+			requestBody: { values: [[formula]] },
+		});
+	}
+}
+
+async function writeMetrics() {
+	const values = [
+		["Metric", "Value"],
+		["Ready for Playtest", `=COUNTIF('${mainTab}'!E:E,"Ready for Playtest")`],
+		["Claimed", `=COUNTIF('${mainTab}'!E:E,"Claimed")`],
+		["Needs Author", `=COUNTIF('${mainTab}'!E:E,"Needs Author")`],
+		["Ready for Maintainer", `=COUNTIF('${mainTab}'!E:E,"Ready for Maintainer")`],
+		["Stale", `=COUNTIF('${mainTab}'!E:E,"Stale")`],
+		["Merged", `=COUNTIF('${mainTab}'!E:E,"Merged")`],
+		["Oldest Active PR Age", `=MAX(FILTER('${mainTab}'!L:L,'${mainTab}'!E:E<>"Merged",'${mainTab}'!E:E<>"Closed"))`],
+	];
+	await sheets.spreadsheets.values.update({
+		spreadsheetId,
+		range: quoteRange("Metrics", "A1"),
+		valueInputOption: "USER_ENTERED",
+		requestBody: { values },
+	});
+}
+
+function quoteRange(sheetName, a1) {
+	return `'${sheetName.replaceAll("'", "''")}'!${a1}`;
+}
+
+function columnLetter(index) {
+	let value = "";
+	let current = index;
+	while (current > 0) {
+		const remainder = (current - 1) % 26;
+		value = String.fromCharCode(65 + remainder) + value;
+		current = Math.floor((current - 1) / 26);
+	}
+	return value;
+}

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -1,179 +1,58 @@
 name: Sprig Auto Triage
+
 on:
   pull_request_target:
-    types: [opened, labeled, synchronized]
-  workflow_dispatch: 
+    types: [opened, edited, labeled, unlabeled, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 permissions:
-  pull-requests: write
-  issues: write
   contents: read
+  issues: write
+  pull-requests: read
 
 jobs:
-  triage-comment:
+  prompt-for-submission-label:
     if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
-      - name: System Message
+      - name: Prompt for submission label
         uses: actions/github-script@v7
         with:
           script: |
-            try {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `[Auto Triage] PR detected. Apply \`submission\` label to run validation.`
-              });
-            } catch (e) { console.log("Initial comment blocked: " + e.message); }
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Apply the `Submission` label to run Sprig submission validation."
+            });
 
   validate-submission:
     if: |
-      (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'submission')) ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'Submission') ||
+      contains(github.event.pull_request.labels.*.name, 'submission')
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - name: Checkout PR Code
-        uses: actions/checkout@v4
+      - name: Checkout trusted automation
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.workflow_dispatch.ref || github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: automation
+          persist-credentials: false
+
+      - name: Checkout submitted files
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: submission
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Run CLI Validation
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-
-            // --- ENGINES ---
-            const analyze = (c) => c.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '').replace(/(let|const|var)\s+\w+/g, '$1 VAR').replace(/\s+/g, '').toLowerCase();
-            const checkSimilarity = (a, b) => {
-              const s1 = analyze(a); const s2 = analyze(b);
-              const chunks = (s) => {
-                const set = new Set();
-                for (let i = 0; i <= s.length - 10; i++) set.add(s.substring(i, i + 10));
-                return set;
-              };
-              const c1 = chunks(s1); const c2 = chunks(s2);
-              if (!c1.size || !c2.size) return 0;
-              return (2.0 * [...c1].filter(x => c2.has(x)).length) / (c1.size + c2.size);
-            };
-
-            // --- UNIVERSAL PR RESOLVER ---
-            let prNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.issue.number;
-
-            if (!prNumber) {
-              console.log("[Auto Triage] No PR/Issue number found. Running in standalone mode.");
-              return; 
-            }
-
-            const { data: pullFiles } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber,
-            });
-
-            let logs = [];
-            let isFailed = false;
-
-            for (const file of pullFiles) {
-              const filename = path.basename(file.filename);
-              
-              if (!file.filename.startsWith('games/')) {
-                logs.push(`- It looks like "${file.filename}" is outside the games folder. Only files in /games are allowed.`);
-                isFailed = true; continue;
-              }
-              if (file.status !== 'added') {
-                logs.push(`- Heads up: "${filename}" was modified, but you can only add new games here.`);
-                isFailed = true; continue;
-              }
-
-              if (filename.endsWith('.js')) {
-                const content = fs.readFileSync(file.filename, 'utf8');
-
-                if (!/^[a-zA-Z0-9-_]+\.js$/.test(filename)) {
-                  logs.push(`- The filename "${filename}" should only use letters, numbers, and dashes.`);
-                  isFailed = true;
-                }
-
-                // --- UPDATED METADATA LOGIC (Order Independent) ---
-                const tags = ['@title:', '@author:', '@description:', '@tags:', '@addedOn:'];
-                const missing = tags.filter(t => !content.includes(t));
-                
-                if (missing.length > 0) {
-                  logs.push(`- The metadata header in "${filename}" is missing or formatted incorrectly (missing ${missing.join(' ')}).`);
-                  isFailed = true;
-                } else {
-                  // Extract values for specific checks
-                  const getVal = (tag) => {
-                    const r = new RegExp(`${tag}\\s*([\\s\\S]*?)(?=@\\w+:|\\*\\/)`);
-                    const m = content.match(r);
-                    return m ? m[1].trim() : "";
-                  };
-
-                  const title = getVal('@title:');
-                  const author = getVal('@author:');
-                  const addedOn = getVal('@addedOn:');
-
-                  if (title.includes("getting_started") || author.includes("leo, edits")) {
-                    logs.push(`- It looks like "${filename}" still has some example/template values in the metadata.`);
-                    isFailed = true;
-                  }
-
-                  const subD = new Date(addedOn);
-                  const diff = Math.abs(new Date() - subD) / (1000 * 60 * 60 * 24 * 30.44);
-                  if (isNaN(subD.getTime()) || diff > 6) {
-                    logs.push(`- The date in "${filename}" doesn't look right. Please set it to the current date.`);
-                    isFailed = true;
-                  }
-                }
-
-                if ([/document\./i, /window\./i, /alert\(/i, /fetch\(/i].some(r => r.test(content))) {
-                  logs.push(`- Found some non-Sprig APIs (like window or fetch) in "${filename}". Please remove them.`);
-                  isFailed = true;
-                }
-
-                const gamesList = fs.readdirSync('games').filter(f => f.endsWith('.js'));
-                for (const existing of gamesList) {
-                  if (file.filename === `games/${existing}`) continue;
-                  const score = checkSimilarity(content, fs.readFileSync(path.join('games', existing), 'utf8'));
-                  if (score > 0.49) {
-                    const rawUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/raw/main/games/${existing}`;
-                    logs.push(`- This code looks very similar to [${existing}](${rawUrl}). Is this a remix or a duplicate?`);
-                    break;
-                  }
-                }
-              }
-            }
-
-            // --- DEFENSIVE REPORTING ---
-            const statusIcon = isFailed ? "❌" : "✅";
-            const statusTitle = isFailed ? "Submission Issues Found" : "Submission Verified";
-            
-            let body = `### ${statusIcon} [Auto Triage] ${statusTitle}\n\`\`\`text\n`;
-            body += logs.length ? logs.join('\n') : "Everything looks great! Your submission is ready be reviewed.";
-            body += "\n```\n";
-            
-            body += "#### [TOOLS]\n";
-            const headSha = context.payload.pull_request?.head?.sha || context.sha;
-            pullFiles.filter(f => f.filename.endsWith('.js')).forEach(f => {
-              const raw = `https://github.com/${context.repo.owner}/${context.repo.repo}/raw/${headSha}/${f.filename}`;
-              body += `- [VIEW_RAW](${raw}) : ${path.basename(f.filename)}\n`;
-            });
-
-            try {
-              await github.rest.issues.createComment({
-                issue_number: prNumber, 
-                owner: context.repo.owner, 
-                repo: context.repo.repo, 
-                body
-              });
-            } catch (e) {
-              console.log("[Auto Triage] Commenting failed. Logs:");
-              console.log(body);
-            }
-
-            if (isFailed) process.exit(1);
+      - name: Validate submission
+        run: node automation/.github/scripts/auto-triage.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          SUBMISSION_PATH: ${{ github.workspace }}/submission
+          SPRIG_REVIEW_BASE_URL: https://sprig.hackclub.com/editor

--- a/.github/workflows/duplicate-submission-labeler.yml
+++ b/.github/workflows/duplicate-submission-labeler.yml
@@ -5,10 +5,12 @@ on:
 
 jobs:
   label-duplicates:
-    if: contains(github.event.pull_request.labels.*.name, 'submission')
+    if: contains(github.event.pull_request.labels.*.name, 'Submission') || contains(github.event.pull_request.labels.*.name, 'submission')
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - name: Check and Label
         env:
@@ -16,11 +18,13 @@ jobs:
           GH_REPO: ${{ github.repository }}
           USER_LOGIN: ${{ github.event.pull_request.user.login }}
         run: |
+          gh label create "Potential Duplicate" --color "8250df" --description "Author has more than one open submission" --force
+
           # 1. Fetch all open PRs from this user (ignore the label for a second)
           ALL_USER_PRS=$(gh pr list --state open --author "$USER_LOGIN" --json number,labels --limit 100)
           
-          # 2. Use 'jq' to filter that list for only those that have the "submission" label
-          SUBMISSION_PRS=$(echo "$ALL_USER_PRS" | jq -r '.[] | select(.labels[].name == "submission") | .number')
+          # 2. Use 'jq' to filter that list for only those that have the submission label
+          SUBMISSION_PRS=$(echo "$ALL_USER_PRS" | jq -r '.[] | select(.labels[].name | ascii_downcase == "submission") | .number')
           
           PR_COUNT=$(echo "$SUBMISSION_PRS" | wc -w)
 
@@ -28,10 +32,10 @@ jobs:
           if [ "$PR_COUNT" -gt 1 ]; then
             for PR_NUM in $SUBMISSION_PRS; do
               # Double check if duplicate label is already there
-              HAS_DUPE_LABEL=$(gh pr view "$PR_NUM" --json labels --jq '.labels[].name' | grep -i "potential-duplicate" || true)
+              HAS_DUPE_LABEL=$(gh pr view "$PR_NUM" --json labels --jq '.labels[].name' | grep -i "Potential Duplicate" || true)
               
               if [ -z "$HAS_DUPE_LABEL" ]; then
-                gh pr edit "$PR_NUM" --add-label "potential-duplicate"
+                gh pr edit "$PR_NUM" --add-label "Potential Duplicate"
               fi
             done
           fi

--- a/.github/workflows/review-commands.yml
+++ b/.github/workflows/review-commands.yml
@@ -1,0 +1,28 @@
+name: Sprig Review Commands
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  handle-command:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout automation
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Run review command
+        run: node .github/scripts/review-commands.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}

--- a/.github/workflows/stale-review-queue.yml
+++ b/.github/workflows/stale-review-queue.yml
@@ -1,0 +1,27 @@
+name: Stale Sprig Review Queue
+
+on:
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  stale-review-queue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout automation
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Process stale submissions
+        run: node .github/scripts/stale-review-queue.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/sync-review-sheet.yml
+++ b/.github/workflows/sync-review-sheet.yml
@@ -1,0 +1,44 @@
+name: Sync Sprig Review Sheet
+
+on:
+  pull_request_target:
+    types: [opened, edited, labeled, unlabeled, synchronize, reopened, closed]
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  sync-sheet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout automation
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install Google Sheets client
+        run: npm install --no-save googleapis
+
+      - name: Sync review sheet
+        run: node .github/scripts/sync-review-sheet.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+          GOOGLE_SHEET_ID: ${{ secrets.GOOGLE_SHEET_ID }}
+          SPRIG_REVIEW_SHEET_TAB: All

--- a/docs/APP_REVIEW_AUTOMATION.md
+++ b/docs/APP_REVIEW_AUTOMATION.md
@@ -1,0 +1,122 @@
+# Sprig App Review Automation
+
+This workflow keeps GitHub as the source of truth and keeps Google Sheets as the team dashboard.
+
+## Reviewer Flow
+
+1. Open the `Ready for Playtest` Sheet tab or this GitHub search:
+   `is:pr is:open label:"Ready for Playtest" -label:"Plagiarism Risk" sort:created-asc`
+2. Comment `/claim` on the PR.
+3. Use the bot's `Play in Sprig Editor` link.
+4. Play for at least one minute.
+5. Leave a GitHub review:
+   - Request changes if the author needs to fix something.
+   - Approve if it is ready.
+6. Add a note when useful:
+   `/triage-note controls are confusing on mobile`
+7. If approved, comment `/ready-maintainer`.
+8. If changes are needed, comment `/needs-author <reason>`.
+
+## Reviewer Commands
+
+| Command | Result |
+| --- | --- |
+| `/claim` | Assigns the commenter and adds `Claimed`. |
+| `/unclaim` | Removes the commenter from assignees and removes `Claimed` if nobody is assigned. |
+| `/triage-note <text>` | Saves reviewer context for the Sheet. |
+| `/needs-author <reason>` | Moves the PR to `Needs Author` and marks it triaged. |
+| `/ready-maintainer <note>` | Moves the PR to `Ready for Maintainer` and marks it triaged. |
+| `/ai-concern <reason>` | Adds `AI Concern` and moves the PR to `Needs Author`. |
+| `/plagiarism-risk <reason>` | Adds `Plagiarism Risk` for lead review. |
+
+## Labels
+
+Human labels are used so the queue is readable in GitHub.
+
+| Label | Meaning |
+| --- | --- |
+| `Submission` | Game submission automation should process. |
+| `Verified` | Automated checks passed. |
+| `Failed` | Automated checks failed. |
+| `Ready for Playtest` | Reviewer can playtest. |
+| `Needs Author` | Author needs to change something. |
+| `Triaged` | Human review happened at least once. |
+| `Ready for Maintainer` | Reviewer thinks it can merge. |
+| `Plagiarism Risk` | Similarity or reviewer concern needs lead review. |
+| `AI Concern` | Author should explain AI usage. |
+| `Potential Duplicate` | Author has multiple open submissions. |
+| `Keep Open` | Stale automation should not close this PR. |
+| `Stale` | PR needs queue cleanup. |
+| `Claimed` | Reviewer is actively handling this PR. |
+
+Only one main queue label should be active at a time:
+
+- `Ready for Playtest`
+- `Needs Author`
+- `Ready for Maintainer`
+- `Stale`
+
+`Failed` is a validation flag, not a queue state. Failed submissions should also have `Needs Author`.
+
+## Automated Checks
+
+The auto-triage workflow checks:
+
+- PR body author field
+- PR body about blurb
+- PR body gameplay description
+- required checklist boxes
+- exactly one new `games/*.js` file
+- no changed files outside the allowed submission paths
+- optional image path under `games/img/`
+- optional image basename matching the game file
+- filename using only letters, numbers, `-`, and `_`
+- metadata fields: `@title`, `@author`, `@description`, `@tags`, `@addedOn`
+- parseable non-empty tag array
+- recent `YYYY-MM-DD` date
+- unique game title
+- no obvious browser-only APIs
+- rough similarity against existing games
+
+Images are optional. If no image is added, the check passes and the comment says the gallery can use a generated/default thumbnail.
+
+## Google Sheets Setup
+
+Create a Google Cloud service account and enable the Google Sheets API.
+
+1. Create a service account.
+2. Create a JSON key.
+3. Share the review Sheet with the service account email as an editor.
+4. Add these repository secrets:
+   - `GOOGLE_SERVICE_ACCOUNT_JSON`
+   - `GOOGLE_SHEET_ID`
+
+The sync workflow creates these tabs:
+
+- `All`
+- `Ready for Playtest`
+- `Claimed`
+- `Needs Author`
+- `Ready for Maintainer`
+- `Stale`
+- `Merged`
+- `Metrics`
+
+The `All` tab is the database. Other tabs are filtered views.
+
+Manual notes should go in `Internal Note`. Bot-owned columns may be overwritten on every sync.
+
+## Stale Rules
+
+- `Needs Author` or `Failed` for 7 days: mark `Stale` and remind the author.
+- `Needs Author` or `Failed` for 14 days: close unless `Keep Open` or `Plagiarism Risk`.
+- `Ready for Maintainer` for 7 days: remind maintainers.
+- `Claimed` for 3 days without movement: unclaim.
+
+## Review Link
+
+Bot comments include:
+
+`/editor?review=true&raw=<raw-github-url>&pr=<number>&repo=<owner/repo>`
+
+The editor fetches the raw GitHub file, loads it without login, shows review controls, and avoids saving review code into the reviewer's local game.

--- a/src/components/big-interactive-pages/editor.module.css
+++ b/src/components/big-interactive-pages/editor.module.css
@@ -30,6 +30,64 @@
 	border-bottom: none;
 }
 
+.reviewBanner {
+	border: 2px solid var(--accent);
+	border-bottom: none;
+	background: color-mix(in srgb, var(--accent) 10%, white);
+	color: var(--accent);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 8px 10px;
+	font-size: 0.9rem;
+	line-height: 1.3;
+}
+
+.reviewBanner strong {
+	display: block;
+	font-weight: 700;
+}
+
+.reviewBanner span {
+	color: var(--fg-muted, #555);
+}
+
+.reviewLinks {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+	justify-content: flex-end;
+}
+
+.reviewLinks a,
+.reviewLinks button {
+	color: var(--accent);
+	background: white;
+	border: 1px solid var(--accent);
+	border-radius: 4px;
+	font: inherit;
+	font-weight: 700;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 8px;
+	text-decoration: none;
+	cursor: var(--cursor-interactive);
+}
+
+.reviewLinks a:hover,
+.reviewLinks button:hover {
+	background: var(--accent);
+	color: white;
+}
+
+.reviewLinks :global(svg) {
+	width: 1em;
+	height: 1em;
+}
+
 .codeContainer .playButton {
 	position: absolute;
 	top: 0;

--- a/src/components/big-interactive-pages/editor.tsx
+++ b/src/components/big-interactive-pages/editor.tsx
@@ -3,6 +3,9 @@ import CodeMirror from "../codemirror";
 import Navbar from "../navbar-editor";
 import {
 	IoClose,
+	IoCopyOutline,
+	IoOpenOutline,
+	IoReloadOutline,
 	IoStopCircleOutline,
 	IoVolumeHighOutline,
 	IoVolumeMuteOutline,
@@ -14,7 +17,7 @@ import {
 	useSignalEffect,
 } from "@preact/signals";
 import { useEffect, useRef, useState} from "preact/hooks";
-import { codeMirror, errorLog, isNewSaveStrat, muted, type PersistenceState, type RoomState,  screenRef, cleanupRef, reviewState } from "../../lib/state";
+import { codeMirror, errorLog, isNewSaveStrat, muted, type PersistenceState, type RoomState,  screenRef, cleanupRef } from "../../lib/state";
 import EditorModal from "../popups-etc/editor-modal";
 import { runGame, _performSyntaxCheck } from "../../lib/engine";
 import DraftWarningModal from "../popups-etc/draft-warning";
@@ -76,6 +79,12 @@ export const onRun = async () => {
 interface EditorProps {
 	persistenceState: Signal<PersistenceState>;
 	roomState?: Signal<RoomState> | undefined;
+	review?: {
+		code?: string;
+		rawUrl?: string;
+		prUrl?: string;
+		error?: string;
+	};
 	cookies: {
 		outputAreaSize: number | null;
 		helpAreaSize: number | null;
@@ -264,10 +273,12 @@ const exitTutorial = (persistenceState: Signal<PersistenceState>, sessionId: str
 	}
 };
 
-export default function Editor({ persistenceState, cookies, roomState }: EditorProps) {
+export default function Editor({ persistenceState, cookies, roomState, review }: EditorProps) {
 	const outputArea = useRef<HTMLDivElement>(null);
 	const screenContainer = useRef<HTMLDivElement>(null);
 	const screenControls = useRef<HTMLDivElement>(null);
+	const reviewAutoRun = useRef(false);
+	const isReviewMode = !!review;
 
 	const [sessionId] = useState(nanoid());
 
@@ -514,6 +525,8 @@ export default function Editor({ persistenceState, cookies, roomState }: EditorP
 	}
 	else if (persistenceState.value.kind === PersistenceStateKind.SHARED)
 		initialCode = persistenceState.value.code;
+	else if (review?.code)
+		initialCode = review.code;
 	else if (persistenceState.value.kind === PersistenceStateKind.IN_MEMORY)
 		initialCode = localStorage.getItem("sprigMemory") ?? defaultExampleCode;
 	else if (isNewSaveStrat.value && persistenceState.value.kind === PersistenceStateKind.COLLAB){
@@ -542,22 +555,6 @@ export default function Editor({ persistenceState, cookies, roomState }: EditorP
 		});
 	}, [initialCode]);
 
-	// Use the review state
-	useEffect(() => {
-		if (reviewState.value.isReviewMode && reviewState.value.reviewCode) {
-			// Set the code in the editor
-			if (codeMirror.value) {
-				codeMirror.value.dispatch({
-					changes: {
-						from: 0,
-						to: codeMirror.value.state.doc.length,
-						insert: reviewState.value.reviewCode
-					}
-				});
-			}
-		}
-	}, [reviewState.value.isReviewMode, reviewState.value.reviewCode]);
-
 	return (
 		roomState != undefined && persistenceState.value.kind === PersistenceStateKind.COLLAB && typeof persistenceState.value.game === 'string' 
 		? 
@@ -571,6 +568,32 @@ export default function Editor({ persistenceState, cookies, roomState }: EditorP
 
 			<div class={styles.pageMain}>
 				<div className={styles.codeContainer}>
+					{isReviewMode && (
+						<div class={styles.reviewBanner}>
+							<div>
+								<strong>Review Mode</strong>
+								<span>{review?.error ?? "Loaded from pull request source. Edits here stay local."}</span>
+							</div>
+							<div class={styles.reviewLinks}>
+								{review?.prUrl && (
+									<a href={review.prUrl} target="_blank" rel="noreferrer">
+										<IoOpenOutline /> PR
+									</a>
+								)}
+								{review?.rawUrl && (
+									<a href={review.rawUrl} target="_blank" rel="noreferrer">
+										<IoOpenOutline /> Raw
+									</a>
+								)}
+								<button type="button" onClick={onRun}>
+									<IoReloadOutline /> Restart
+								</button>
+								<button type="button" onClick={() => navigator.clipboard.writeText(window.location.href)}>
+									<IoCopyOutline /> Copy Link
+								</button>
+							</div>
+						</div>
+					)}
 					<CodeMirror
 						persistenceState={persistenceState}
 						roomState={roomState}
@@ -579,9 +602,15 @@ export default function Editor({ persistenceState, cookies, roomState }: EditorP
 						onEditorView={(editor) => {
 							codeMirror.value = editor;
 							setTimeout(() => foldAllTemplateLiterals(), 100); // Fold after the document is parsed (gross)
+							if (isReviewMode && review?.code && !reviewAutoRun.current) {
+								reviewAutoRun.current = true;
+								setTimeout(() => onRun(), 500);
+							}
 						}}
 						onRunShortcut={onRun}
 						onCodeChange={() => {
+							if (isReviewMode) return;
+
 							persistenceState.value = {
 								...persistenceState.value,
 								stale: true,

--- a/src/pages/editor.astro
+++ b/src/pages/editor.astro
@@ -4,24 +4,26 @@ import { getSession } from '../lib/game-saving/account'
 import Editor from '../components/big-interactive-pages/editor'
 import StandardHead from '../components/standard-head.astro'
 import { signal } from '@preact/signals'
-import { PersistenceState, reviewState } from '../lib/state'
+import { PersistenceState } from '../lib/state'
 import { mobileUserAgent } from '../lib/utils/mobile'
 import MobileUnsupported from '../components/popups-etc/mobile-unsupported'
 import UploadWarningModal from '../components/popups-etc/upload-failed-warning'
 import { showUploadWarningModal } from '../lib/upload'
 
+const reviewMode = Astro.url.searchParams.get('review') === 'true'
+
 // Redirects for legacy Sprig URLs
 const galleryRegex = /^https:\/\/raw\.githubusercontent\.com\/hackclub\/sprig\/main\/games\/(.+)\.js$/
 const galleryMatches = Astro.url.searchParams.get('file')?.match(galleryRegex) ?? null
-if (galleryMatches) return Astro.redirect(`/gallery/${galleryMatches[1]}`, 302)
+if (!reviewMode && galleryMatches) return Astro.redirect(`/gallery/${galleryMatches[1]}`, 302)
 if (Astro.url.searchParams.has('id'))
 	return Astro.redirect(`/legacy-bucket/${Astro.url.searchParams.get('id')}`, 302)
 
 const tempGame = Astro.cookies.get('sprigTempGame')?.value
-if (tempGame) return Astro.redirect(`/~/${encodeURIComponent(tempGame)}`, 302)
+if (tempGame && !reviewMode) return Astro.redirect(`/~/${encodeURIComponent(tempGame)}`, 302)
 
 const session = await getSession(Astro.cookies)
-if (session?.session.full) return Astro.redirect('/~', 302)
+if (session?.session.full && !reviewMode) return Astro.redirect('/~', 302)
 
 const persistenceState = signal<PersistenceState>({
 	kind: 'IN_MEMORY',
@@ -31,20 +33,55 @@ const persistenceState = signal<PersistenceState>({
 })
 const isMobile = mobileUserAgent(Astro.request.headers.get('user-agent') ?? '')
 
-// Check for review mode
-const reviewMode = Astro.url.searchParams.get('review') === 'true'
-const reviewCode = reviewMode ? Astro.url.searchParams.get('code') : null
+const review = reviewMode ? await getReviewPayload(Astro.url) : undefined
 
 // If no session and not in review mode, redirect to login
 if (!session?.session.full && !reviewMode) {
 	return Astro.redirect('/login', 302)
 }
 
-// Set review state
-if (reviewMode && reviewCode) {
-	reviewState.value = {
-		isReviewMode: true,
-		reviewCode: decodeURIComponent(reviewCode)
+async function getReviewPayload(url: URL) {
+	const rawUrl = normalizeGitHubRawUrl(url.searchParams.get('raw') ?? url.searchParams.get('file'))
+	const code = url.searchParams.get('code')
+	const repo = url.searchParams.get('repo')
+	const pr = url.searchParams.get('pr')
+	const prUrl = repo && pr ? `https://github.com/${repo}/pull/${pr}` : undefined
+
+	if (code) {
+		return { code, rawUrl: undefined, prUrl, error: undefined }
+	}
+
+	if (!rawUrl) {
+		return { code: undefined, rawUrl: undefined, prUrl, error: 'Review link is missing a valid GitHub raw URL.' }
+	}
+
+	try {
+		const response = await fetch(rawUrl, { headers: { Accept: 'text/plain' } })
+		if (!response.ok) {
+			return { code: undefined, rawUrl, prUrl, error: `Could not load game code from GitHub (${response.status}).` }
+		}
+		return { code: await response.text(), rawUrl, prUrl, error: undefined }
+	} catch {
+		return { code: undefined, rawUrl, prUrl, error: 'Could not load game code from GitHub.' }
+	}
+}
+
+function normalizeGitHubRawUrl(value: string | null) {
+	if (!value) return null
+	try {
+		const url = new URL(value)
+		if (url.protocol !== 'https:') return null
+		if (url.hostname === 'raw.githubusercontent.com') return url.toString()
+		if (url.hostname !== 'github.com') return null
+
+		const parts = url.pathname.split('/').filter(Boolean)
+		if (parts.length < 5) return null
+		const [owner, repo, mode, ref, ...filePath] = parts
+		if (!owner || !repo || !ref || !filePath.length) return null
+		if (mode !== 'raw' && mode !== 'blob') return null
+		return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${filePath.join('/')}`
+	} catch {
+		return null
 	}
 }
 ---
@@ -54,13 +91,15 @@ if (reviewMode && reviewCode) {
 		<StandardHead title='Editor' />
 	</head>
 	<body>
-		<Editor
-			client:load
-			persistenceState={persistenceState}
-			cookies={{
-				outputAreaSize: Astro.cookies.get('outputAreaSize')?.number(),
-				hideHelp: Astro.cookies.get('hideHelp')?.boolean()
-			}}
+			<Editor
+				client:load
+				persistenceState={persistenceState}
+				review={review}
+				cookies={{
+					outputAreaSize: Astro.cookies.get('outputAreaSize')?.number(),
+					helpAreaSize: Astro.cookies.get('helpAreaSize')?.number(),
+					hideHelp: Astro.cookies.get('hideHelp')?.boolean()
+				}}
 		/>
 		{isMobile ? <MobileUnsupported /> : null}
 		<UploadWarningModal client:load showWarning={showUploadWarningModal} />


### PR DESCRIPTION
This pull request introduces a new set of GitHub Actions scripts to automate and streamline the review process for pull requests. The main changes include the addition of scripts for handling review commands, automated stale PR management, and a utility module for consistent label and API handling. These scripts help automate reviewer assignments, label management, stale PR reminders, and state transitions, making the review workflow more efficient and less error-prone.

**New Review Automation Scripts**

- Added `.github/scripts/review-commands.mjs`, a script to process review commands (e.g., `/claim`, `/unclaim`, `/triage-note`, `/needs-author`, `/ready-maintainer`, `/ai-concern`, `/plagiarism-risk`) from PR comments. This script assigns reviewers, manages labels, and posts automated replies based on commands.
- Added `.github/scripts/stale-review-queue.mjs`, a script to automatically manage stale PRs by:
  - Closing PRs that have been waiting on author changes for 14 days
  - Marking PRs as stale after 7 days of inactivity
  - Unclaiming reviews after 3 days of inactivity
  - Reminding maintainers if a PR is ready for review for 7 days

**Shared Utilities for Review Automation**

- Introduced `.github/scripts/review-utils.mjs`, a shared utility module providing:
  - Standardized label definitions and management functions
  - GitHub API request helpers (including paginated requests)
  - Functions for getting/setting PR state, adding/removing labels, and posting/updating bot comments
  - Utilities for calculating time-based actions (e.g., days between events)