### PR TITLE
Fix gallery play page

### DIFF
--- a/src/pages/gallery/play/[id].astro
+++ b/src/pages/gallery/play/[id].astro
@@ -160,9 +160,9 @@ const props: Props = {
       display: flex;
       flex-direction: column;
       width: 100%;
-      height: 800px;
+      min-height: 0;
       position: relative;
-      overflow: hidden;
+      overflow: auto;
     }
 
     :global(.rootContainer) {

--- a/src/pages/gallery/play/[id].astro
+++ b/src/pages/gallery/play/[id].astro
@@ -9,7 +9,7 @@ import DesktopPlayer from '../../../components/big-interactive-pages/desktop-pla
 import fs from 'fs'
 import path from 'path'
 import Button from '../../../components/design-system/button'
-import { IoShuffle } from 'react-icons/io5'
+import { IoShuffle, IoCode } from 'react-icons/io5'
 
 interface Props {
   game: GameMetadata;
@@ -190,11 +190,16 @@ const props: Props = {
   </style>
 </head>
 <body>
-  <MainNavbar session={props.session}>
-    <a href={`/~/new-game?remix=${props.game.filename}`}>
-      <Button icon={IoShuffle}>Remix Game</Button>
+<MainNavbar session={props.session}>
+  {type !== 'document' && (
+    <a href={`/gallery/${props.game.filename}`}>
+      <Button icon={IoCode}>View Code</Button>
     </a>
-  </MainNavbar>
+  )}
+  <a href={`/~/new-game?remix=${props.game.filename}`}>
+    <Button icon={IoShuffle}>Remix Game</Button>
+  </a>
+</MainNavbar>
   <div class="game-view">
     <div class="game-header">
       <div class="game-info">


### PR DESCRIPTION
Fixes #3467
Hi, I picked up this issue and here's what I found and what I did about it.
When you click on a game in the gallery to play it, there's only a "Remix Game" button, there's no way to just view the code without remixing it first, which was kind of the original point of the issue. So I added a button for that.
I also checked it on a 1366x768 screen (a pretty normal laptop resolution) and the bottom part of the game screen was getting cut off, including the control buttons. So on a smaller screen you couldn't actually press some of the buttons, which is obviously not great.
What I changed:

Added a "View Code" button next to the Remix button, so you can see the code without having to remix the game first. It only shows up for actual gallery games though, since remixed or saved games don't have a real code page, so I hid the button for those.
The game screen was stuck at a fixed 800px height no matter what your screen size was, which is why it didn't fit on smaller screens. I changed it so it resizes based on the actual screen instead of being a fixed number.

For testing, I don't have git set up locally so I edited everything directly through GitHub's website. I tested it using the Vercel preview link that gets generated automatically for PRs here, which I didn't know about until now but it worked well. I checked a normal game and the button showed up and worked, checked a remixed game and the button correctly didn't show up, and then shrunk my browser down to 1366x768 and everything showed up properly this time, buttons included.
This is one of my first contributions here, so let me know if anything's off or if I should've approached it differently.