### PR TITLE
Fix errors on astro-build CI/CD

### DIFF
--- a/games/Memory-Game-Ultimate-Edition.js
+++ b/games/Memory-Game-Ultimate-Edition.js
@@ -5,7 +5,7 @@ https://sprig.hackclub.com/gallery/getting_started
 @title: Memory Game V2
 @description: Memory Game V4 is a fun Sprig memory-matching game where players choose a board size and test how quickly they can find all the matching pairs. 
 @author: Ishank 
-@tags:['memory-game', 'matching', 'brain-training]
+@tags: ['memory-game', 'matching', 'brain-training']
 @addedOn: 2026-06-15
 */
 

--- a/games/Polymage.js
+++ b/games/Polymage.js
@@ -1,7 +1,7 @@
 /*
 @title: Polymage
 @author: Coderpillar
-@tags: [rogue]
+@tags: ['rogue']
 @addedOn: 2026-05-28
 @description: thx to davnotdev for code insperation
 */


### PR DESCRIPTION
This pull request fixes the tag metadata on 2 games.

This should fix the broken astro-build and docker-build CI/CD for everyone.
The games in question were Memory-Game-Ultimate-Edition.js and Polymage.js
